### PR TITLE
chore: raise coverage floor to 60% (PR-a of 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ source = ["opnsense_openapi"]
 skip_covered = false
 show_missing = true
 precision = 2
-fail_under = 80
+fail_under = 60
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,176 @@
+"""Shared pytest fixtures for the opnsense-openapi test suite.
+
+This module centralizes reusable fixtures so individual test modules can stay
+focused on the behavior under test. Fixtures here are used by multiple test
+modules and follow the patterns established during the initial coverage
+ratchet (issue #6).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def minimal_openapi_spec() -> dict[str, Any]:
+    """Return a minimal OpenAPI 3.0.3 spec dictionary suitable for most tests.
+
+    The spec contains a small but representative mix of paths, components, and
+    response shapes so consumers can exercise path iteration, schema lookup,
+    and `$ref` resolution.
+
+    Returns:
+        A dict representing a minimal OpenAPI spec.
+    """
+    return {
+        "openapi": "3.0.3",
+        "info": {"title": "Test API", "version": "24.7"},
+        "paths": {
+            "/api/core/firmware/info": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "product_version": {"type": "string"},
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/api/firewall/alias/set": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {"schema": {"$ref": "#/components/schemas/Alias"}}
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "object"},
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Alias": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                        "name": {"type": "string"},
+                        "type": {"type": "string", "enum": ["host", "network"]},
+                    },
+                }
+            }
+        },
+    }
+
+
+@pytest.fixture
+def minimal_openapi_spec_file(tmp_path: Path, minimal_openapi_spec: dict[str, Any]) -> Path:
+    """Write `minimal_openapi_spec` to a JSON file under ``tmp_path``.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        minimal_openapi_spec: The fixture-provided spec dict.
+
+    Returns:
+        Path to the written JSON spec file.
+    """
+    spec_file = tmp_path / "spec.json"
+    spec_file.write_text(json.dumps(minimal_openapi_spec))
+    return spec_file
+
+
+@pytest.fixture
+def mock_httpx_response() -> Callable[..., httpx.Response]:
+    """Return a factory that builds :class:`httpx.Response` objects.
+
+    The factory exposes the same keyword arguments as ``httpx.Response`` but
+    pre-populates a sensible JSON content-type when ``json`` is supplied and
+    no explicit ``headers`` override is given.
+
+    Returns:
+        A callable that produces ``httpx.Response`` instances for tests.
+    """
+
+    def _build(
+        status_code: int = 200,
+        *,
+        json: Any = None,
+        text: str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        response_headers = headers
+        if response_headers is None and json is not None:
+            response_headers = {"Content-Type": "application/json"}
+        kwargs: dict[str, Any] = {"headers": response_headers or {}}
+        if json is not None:
+            kwargs["json"] = json
+        if text is not None:
+            kwargs["text"] = text
+        return httpx.Response(status_code, **kwargs)
+
+    return _build
+
+
+@pytest.fixture
+def fake_generated_module() -> MagicMock:
+    """Return a ``MagicMock`` shaped like a generated API function module.
+
+    The mock exposes ``sync``, ``sync_detailed``, ``asyncio``, and
+    ``asyncio_detailed`` attributes so tests of the
+    :class:`opnsense_openapi.client.generated_api.FunctionProxy` chain can
+    assert call delegation without importing real generated code.
+
+    Returns:
+        A ``MagicMock`` with the four generated-API call attributes configured.
+    """
+    module = MagicMock()
+    module.sync = MagicMock(return_value={"sync": True})
+    module.sync_detailed = MagicMock(return_value={"sync_detailed": True})
+
+    async def _async_call(**_kwargs: Any) -> dict[str, bool]:
+        return {"asyncio": True}
+
+    async def _async_detailed(**_kwargs: Any) -> dict[str, bool]:
+        return {"asyncio_detailed": True}
+
+    module.asyncio = _async_call
+    module.asyncio_detailed = _async_detailed
+    return module
+
+
+@pytest.fixture
+def mock_subprocess_run() -> Iterator[MagicMock]:
+    """Patch ``subprocess.run`` and yield the resulting ``MagicMock``.
+
+    The default return value is a ``MagicMock`` with ``returncode=0`` and an
+    empty ``stdout`` / ``stderr``. Tests can customize ``return_value`` or
+    ``side_effect`` as needed.
+
+    Yields:
+        The ``MagicMock`` replacing :func:`subprocess.run`.
+    """
+    with patch("subprocess.run") as mocked:
+        mocked.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        yield mocked

--- a/tests/test_client_auto_generate.py
+++ b/tests/test_client_auto_generate.py
@@ -1,0 +1,97 @@
+"""Tests for :func:`opnsense_openapi.client.base._auto_generate_client`.
+
+These cover the module-level client auto-generation helper in isolation. Tests
+for ``OPNsenseClient`` itself are intentionally scoped to PR-b.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from opnsense_openapi.client.base import _auto_generate_client
+
+
+def test_auto_generate_returns_false_when_spec_missing(tmp_path: Path) -> None:
+    """_auto_generate_client returns False if no spec file matches the version."""
+    with patch(
+        "opnsense_openapi.client.base.find_best_matching_spec",
+        side_effect=FileNotFoundError("no spec"),
+    ):
+        assert _auto_generate_client("99.99") is False
+
+
+def test_auto_generate_returns_true_when_client_exists(tmp_path: Path) -> None:
+    """_auto_generate_client short-circuits when the generated client directory exists."""
+    spec_path = tmp_path / "opnsense-24.7.json"
+    spec_path.write_text("{}")
+
+    with (
+        patch(
+            "opnsense_openapi.client.base.find_best_matching_spec",
+            return_value=spec_path,
+        ),
+        patch("pathlib.Path.exists", return_value=True),
+    ):
+        assert _auto_generate_client("24.7") is True
+
+
+def test_auto_generate_returns_false_when_cli_missing(tmp_path: Path) -> None:
+    """_auto_generate_client returns False when openapi-python-client is absent."""
+    spec_path = tmp_path / "opnsense-24.7.json"
+    spec_path.write_text("{}")
+
+    # client_dir.exists() -> False triggers the shutil.which branch.
+    with (
+        patch(
+            "opnsense_openapi.client.base.find_best_matching_spec",
+            return_value=spec_path,
+        ),
+        patch("pathlib.Path.exists", return_value=False),
+        patch("shutil.which", return_value=None),
+    ):
+        assert _auto_generate_client("24.7") is False
+
+
+def test_auto_generate_invokes_client_generator(tmp_path: Path) -> None:
+    """_auto_generate_client shells out to openapi-python-client with expected args."""
+    spec_path = tmp_path / "opnsense-24.7.json"
+    spec_path.write_text("{}")
+
+    with (
+        patch(
+            "opnsense_openapi.client.base.find_best_matching_spec",
+            return_value=spec_path,
+        ),
+        patch("pathlib.Path.exists", return_value=False),
+        patch("shutil.which", return_value="/usr/bin/openapi-python-client"),
+        patch("subprocess.check_call") as check_call,
+    ):
+        assert _auto_generate_client("24.7") is True
+
+    check_call.assert_called_once()
+    cmd = check_call.call_args.args[0]
+    assert cmd[0] == "openapi-python-client"
+    assert "--path" in cmd
+    assert str(spec_path) in cmd
+
+
+def test_auto_generate_returns_false_on_generator_failure(tmp_path: Path) -> None:
+    """_auto_generate_client returns False when the generator subprocess fails."""
+    spec_path = tmp_path / "opnsense-24.7.json"
+    spec_path.write_text("{}")
+
+    with (
+        patch(
+            "opnsense_openapi.client.base.find_best_matching_spec",
+            return_value=spec_path,
+        ),
+        patch("pathlib.Path.exists", return_value=False),
+        patch("shutil.which", return_value="/usr/bin/openapi-python-client"),
+        patch(
+            "subprocess.check_call",
+            side_effect=subprocess.CalledProcessError(returncode=1, cmd=["x"]),
+        ),
+    ):
+        assert _auto_generate_client("24.7") is False

--- a/tests/test_generated_api.py
+++ b/tests/test_generated_api.py
@@ -1,0 +1,162 @@
+"""Tests for :mod:`opnsense_openapi.client.generated_api`."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from opnsense_openapi.client.generated_api import (
+    FunctionProxy,
+    GeneratedAPI,
+    ModuleProxy,
+)
+
+
+def test_generated_api_repr_includes_version() -> None:
+    """GeneratedAPI.__repr__ surfaces the version string."""
+    api = GeneratedAPI(generated_client=MagicMock(), version="25.7.6")
+    assert repr(api) == "GeneratedAPI(version=25.7.6)"
+
+
+def test_generated_api_getattr_returns_module_proxy() -> None:
+    """Attribute access yields a ModuleProxy carrying the normalized version."""
+    client = MagicMock()
+    api = GeneratedAPI(generated_client=client, version="25.7.6")
+
+    proxy = api.core
+
+    assert isinstance(proxy, ModuleProxy)
+    assert proxy._client is client
+    assert proxy._module_name == "core"
+    assert proxy._version_module == "25_7_6"
+
+
+def test_module_proxy_repr_includes_module_name() -> None:
+    """ModuleProxy.__repr__ surfaces the module name."""
+    proxy = ModuleProxy(client=MagicMock(), version_module="25_7_6", module_name="firewall")
+    assert repr(proxy) == "ModuleProxy(module=firewall)"
+
+
+def test_module_proxy_getattr_returns_function_proxy() -> None:
+    """ModuleProxy attribute access yields a FunctionProxy bound to the module."""
+    client = MagicMock()
+    module = ModuleProxy(client=client, version_module="25_7_6", module_name="core")
+
+    func = module.firmware_info
+
+    assert isinstance(func, FunctionProxy)
+    assert func._client is client
+    assert func._module_name == "core"
+    assert func._function_name == "firmware_info"
+    assert func._version_module == "25_7_6"
+
+
+def test_function_proxy_repr_includes_fully_qualified_name() -> None:
+    """FunctionProxy.__repr__ surfaces ``module.function`` for debuggability."""
+    proxy = FunctionProxy(
+        client=MagicMock(),
+        version_module="25_7_6",
+        module_name="core",
+        function_name="firmware_info",
+    )
+    assert repr(proxy) == "FunctionProxy(function=core.firmware_info)"
+
+
+def _build_proxy(client: Any = None) -> FunctionProxy:
+    """Build a FunctionProxy wired to the given client (or a fresh MagicMock)."""
+    return FunctionProxy(
+        client=client if client is not None else MagicMock(),
+        version_module="25_7_6",
+        module_name="core",
+        function_name="firmware_info",
+    )
+
+
+def test_load_function_module_imports_expected_path(fake_generated_module: MagicMock) -> None:
+    """_load_function_module imports the generated module via importlib."""
+    proxy = _build_proxy()
+
+    with patch("importlib.import_module", return_value=fake_generated_module) as imp:
+        module = proxy._load_function_module()
+
+    imp.assert_called_once_with(
+        "opnsense_openapi.generated.v25_7_6.opnsense_openapi_client.api.core.core_firmware_info"
+    )
+    assert module is fake_generated_module
+
+
+def test_load_function_module_caches_result(fake_generated_module: MagicMock) -> None:
+    """Subsequent calls reuse the cached module rather than re-importing."""
+    proxy = _build_proxy()
+
+    with patch("importlib.import_module", return_value=fake_generated_module) as imp:
+        first = proxy._load_function_module()
+        second = proxy._load_function_module()
+
+    assert first is second
+    imp.assert_called_once()
+
+
+def test_load_function_module_converts_import_error(
+    fake_generated_module: MagicMock,
+) -> None:
+    """ImportError is re-raised as AttributeError with a helpful message."""
+    proxy = _build_proxy()
+
+    with (
+        patch("importlib.import_module", side_effect=ImportError("boom")),
+        pytest.raises(AttributeError, match=r"core\.firmware_info"),
+    ):
+        proxy._load_function_module()
+
+
+def test_call_delegates_to_sync(fake_generated_module: MagicMock) -> None:
+    """FunctionProxy.__call__ is shorthand for ``.sync(**kwargs)``."""
+    client = MagicMock()
+    proxy = _build_proxy(client=client)
+
+    with patch("importlib.import_module", return_value=fake_generated_module):
+        result = proxy(foo="bar")
+
+    assert result == {"sync": True}
+    fake_generated_module.sync.assert_called_once_with(client=client, foo="bar")
+
+
+def test_sync_detailed_routes_through_generated_module(
+    fake_generated_module: MagicMock,
+) -> None:
+    """sync_detailed() forwards kwargs to the generated helper."""
+    client = MagicMock()
+    proxy = _build_proxy(client=client)
+
+    with patch("importlib.import_module", return_value=fake_generated_module):
+        result = proxy.sync_detailed(a=1)
+
+    assert result == {"sync_detailed": True}
+    fake_generated_module.sync_detailed.assert_called_once_with(client=client, a=1)
+
+
+def test_asyncio_awaits_generated_coroutine(fake_generated_module: MagicMock) -> None:
+    """asyncio() awaits the generated ``asyncio`` coroutine."""
+    client = MagicMock()
+    proxy = _build_proxy(client=client)
+
+    with patch("importlib.import_module", return_value=fake_generated_module):
+        result = asyncio.run(proxy.asyncio(foo=1))
+
+    assert result == {"asyncio": True}
+
+
+def test_asyncio_detailed_awaits_generated_coroutine(
+    fake_generated_module: MagicMock,
+) -> None:
+    """asyncio_detailed() awaits the generated ``asyncio_detailed`` coroutine."""
+    proxy = _build_proxy()
+
+    with patch("importlib.import_module", return_value=fake_generated_module):
+        result = asyncio.run(proxy.asyncio_detailed())
+
+    assert result == {"asyncio_detailed": True}

--- a/tests/test_source_downloader.py
+++ b/tests/test_source_downloader.py
@@ -1,0 +1,236 @@
+"""Tests for :mod:`opnsense_openapi.downloader.source_downloader`."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from opnsense_openapi.downloader.source_downloader import SourceDownloader
+
+
+def test_initializes_default_cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """SourceDownloader creates the default cache directory on init."""
+    monkeypatch.chdir(tmp_path)
+    downloader = SourceDownloader()
+    assert downloader.cache_dir == Path("tmp/opnsense_source")
+    assert downloader.cache_dir.exists()
+
+
+def test_initializes_custom_cache_dir(tmp_path: Path) -> None:
+    """SourceDownloader creates a caller-provided cache directory."""
+    cache = tmp_path / "custom-cache"
+    downloader = SourceDownloader(cache_dir=cache)
+    assert downloader.cache_dir == cache
+    assert cache.exists()
+
+
+def test_download_rejects_invalid_version(tmp_path: Path) -> None:
+    """download() raises ValueError for malformed version strings."""
+    downloader = SourceDownloader(cache_dir=tmp_path)
+    with pytest.raises(ValueError, match="Invalid version format"):
+        downloader.download("not-a-version")
+
+
+def test_download_returns_cached_controllers_when_present(tmp_path: Path) -> None:
+    """download() skips cloning when the controllers directory already exists."""
+    downloader = SourceDownloader(cache_dir=tmp_path)
+    expected = tmp_path / "24.7" / SourceDownloader.CONTROLLERS_PATH
+    expected.mkdir(parents=True)
+
+    with patch.object(downloader, "_git_clone_tag") as clone:
+        result = downloader.download("24.7")
+
+    assert result == expected
+    clone.assert_not_called()
+
+
+def test_download_removes_cache_when_force(tmp_path: Path) -> None:
+    """download(force=True) wipes the version directory before re-cloning."""
+    downloader = SourceDownloader(cache_dir=tmp_path)
+    version_dir = tmp_path / "24.7"
+    controllers_dir = version_dir / SourceDownloader.CONTROLLERS_PATH
+    controllers_dir.mkdir(parents=True)
+    marker = version_dir / "stale.txt"
+    marker.write_text("old")
+
+    def fake_clone(_tag: str, target: Path) -> None:
+        target.mkdir(parents=True, exist_ok=True)
+        (target / SourceDownloader.CONTROLLERS_PATH).mkdir(parents=True, exist_ok=True)
+
+    with patch.object(downloader, "_git_clone_tag", side_effect=fake_clone) as clone:
+        downloader.download("24.7", force=True)
+
+    assert not marker.exists()
+    clone.assert_called_once()
+
+
+def test_download_falls_back_to_v_prefixed_tag(tmp_path: Path) -> None:
+    """download() retries with a ``v``-prefixed tag when the plain tag fails."""
+    downloader = SourceDownloader(cache_dir=tmp_path)
+    calls: list[str] = []
+
+    def fake_clone(tag: str, target: Path) -> None:
+        calls.append(tag)
+        if tag == "24.7":
+            raise RuntimeError("tag not found")
+        target.mkdir(parents=True, exist_ok=True)
+        (target / SourceDownloader.CONTROLLERS_PATH).mkdir(parents=True, exist_ok=True)
+
+    with patch.object(downloader, "_git_clone_tag", side_effect=fake_clone):
+        result = downloader.download("24.7")
+
+    assert calls == ["24.7", "v24.7"]
+    assert result.exists()
+
+
+def test_download_raises_runtime_error_when_both_tags_fail(tmp_path: Path) -> None:
+    """download() wraps both clone failures in a RuntimeError."""
+    downloader = SourceDownloader(cache_dir=tmp_path)
+
+    def fake_clone(_tag: str, _target: Path) -> None:
+        raise RuntimeError("nope")
+
+    with (
+        patch.object(downloader, "_git_clone_tag", side_effect=fake_clone),
+        pytest.raises(RuntimeError, match=r"Failed to download OPNsense version 24\.7"),
+    ):
+        downloader.download("24.7")
+
+
+def test_download_raises_if_controllers_missing_after_clone(tmp_path: Path) -> None:
+    """download() errors if the controllers directory is absent post-clone."""
+    downloader = SourceDownloader(cache_dir=tmp_path)
+
+    def fake_clone(_tag: str, target: Path) -> None:
+        target.mkdir(parents=True, exist_ok=True)
+        # Intentionally do NOT create controllers subtree.
+
+    with (
+        patch.object(downloader, "_git_clone_tag", side_effect=fake_clone),
+        pytest.raises(RuntimeError, match="Controllers directory not found"),
+    ):
+        downloader.download("24.7")
+
+
+def test_git_clone_tag_invokes_git_with_expected_args(
+    tmp_path: Path, mock_subprocess_run: MagicMock
+) -> None:
+    """_git_clone_tag shells out to git with the documented flags."""
+    downloader = SourceDownloader(cache_dir=tmp_path)
+    target = tmp_path / "24.7"
+
+    downloader._git_clone_tag("24.7", target)
+
+    mock_subprocess_run.assert_called_once()
+    args, kwargs = mock_subprocess_run.call_args
+    assert args[0] == [
+        "git",
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        "24.7",
+        SourceDownloader.GITHUB_REPO,
+        str(target),
+    ]
+    assert kwargs == {"check": True, "capture_output": True, "text": True}
+
+
+def test_git_clone_tag_wraps_called_process_error(
+    tmp_path: Path, mock_subprocess_run: MagicMock
+) -> None:
+    """_git_clone_tag converts ``CalledProcessError`` into ``RuntimeError``."""
+    mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+        returncode=128, cmd=["git"], stderr="fatal: bad tag"
+    )
+    downloader = SourceDownloader(cache_dir=tmp_path)
+    with pytest.raises(RuntimeError, match="fatal: bad tag"):
+        downloader._git_clone_tag("24.7", tmp_path / "24.7")
+
+
+def test_get_available_versions_filters_prereleases(
+    tmp_path: Path, mock_subprocess_run: MagicMock
+) -> None:
+    """get_available_versions() drops RC, beta, alpha and peeled tags."""
+    downloader = SourceDownloader(cache_dir=tmp_path)
+    mock_subprocess_run.return_value = MagicMock(
+        returncode=0,
+        stdout=(
+            "abc refs/tags/24.7\n"
+            "def refs/tags/24.7^{}\n"
+            "ghi refs/tags/24.7-RC1\n"
+            "jkl refs/tags/24.7-rc2\n"
+            "mno refs/tags/24.7-beta1\n"
+            "pqr refs/tags/24.1-alpha\n"
+            "stu refs/tags/25.1\n"
+            "zzz not-a-tag-line\n"
+        ),
+        stderr="",
+    )
+
+    versions = downloader.get_available_versions()
+
+    assert versions == ["25.1", "24.7"]
+
+
+def test_get_available_versions_raises_on_git_failure(
+    tmp_path: Path, mock_subprocess_run: MagicMock
+) -> None:
+    """get_available_versions() wraps git failure into RuntimeError."""
+    mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+        returncode=1, cmd=["git"], stderr="network error"
+    )
+    downloader = SourceDownloader(cache_dir=tmp_path)
+    with pytest.raises(RuntimeError, match="network error"):
+        downloader.get_available_versions()
+
+
+def test_clean_cache_removes_specific_version(tmp_path: Path) -> None:
+    """clean_cache(version) removes only the targeted version directory."""
+    downloader = SourceDownloader(cache_dir=tmp_path)
+    (tmp_path / "24.7").mkdir()
+    (tmp_path / "24.7" / "file").write_text("x")
+    (tmp_path / "25.1").mkdir()
+
+    downloader.clean_cache("24.7")
+
+    assert not (tmp_path / "24.7").exists()
+    assert (tmp_path / "25.1").exists()
+
+
+def test_clean_cache_missing_version_is_noop(tmp_path: Path) -> None:
+    """clean_cache(version) silently skips missing version directories."""
+    downloader = SourceDownloader(cache_dir=tmp_path)
+    # No raise.
+    downloader.clean_cache("99.99")
+
+
+def test_clean_cache_removes_all_when_no_version(tmp_path: Path) -> None:
+    """clean_cache() nukes the entire cache dir and recreates it empty."""
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    downloader = SourceDownloader(cache_dir=cache)
+    (cache / "24.7").mkdir()
+    (cache / "24.7" / "file").write_text("x")
+
+    downloader.clean_cache()
+
+    assert cache.exists()
+    assert list(cache.iterdir()) == []
+
+
+def test_clean_cache_all_handles_missing_cache_dir(tmp_path: Path) -> None:
+    """clean_cache() is a no-op when the cache dir has already been removed."""
+    cache = tmp_path / "cache"
+    downloader = SourceDownloader(cache_dir=cache)
+    # Remove the cache dir that __init__ created.
+    cache.rmdir()
+    assert not cache.exists()
+
+    downloader.clean_cache()
+
+    # Neither branch in the `else` block should raise.
+    assert not cache.exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,74 @@
+"""Tests for :mod:`opnsense_openapi.utils`."""
+
+from __future__ import annotations
+
+import pytest
+
+from opnsense_openapi.utils import to_class_name, to_snake_case, validate_version
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "24.7",
+        "24.7.1",
+        "v24.7",
+        "v24.7.1",
+        "25.1.10",
+        "1.0",
+    ],
+)
+def test_validate_version_accepts_well_formed_versions(version: str) -> None:
+    """validate_version returns True for well-formed version strings."""
+    assert validate_version(version)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "",
+        "invalid",
+        "24",
+        "24.7.1.2",
+        "abc.def",
+        "24.7-rc1",
+        "v",
+        "24.",
+    ],
+)
+def test_validate_version_rejects_malformed_versions(version: str) -> None:
+    """validate_version returns False for malformed version strings."""
+    assert not validate_version(version)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("findAlias", "find_alias"),
+        ("AliasUtil", "alias_util"),
+        ("get", "get"),
+        ("setItem", "set_item"),
+        ("", ""),
+        ("lowercase", "lowercase"),
+        ("HTTPServer", "h_t_t_p_server"),
+    ],
+)
+def test_to_snake_case_conversions(source: str, expected: str) -> None:
+    """to_snake_case converts camel/Pascal case into lowercase underscore form."""
+    assert to_snake_case(source) == expected
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("firewall_alias", "FirewallAlias"),
+        ("test", "Test"),
+        ("api_controller_base", "ApiControllerBase"),
+        ("", ""),
+        ("single", "Single"),
+        ("multi_part_name", "MultiPartName"),
+    ],
+)
+def test_to_class_name_conversions(source: str, expected: str) -> None:
+    """to_class_name joins snake_case tokens into a PascalCase identifier."""
+    assert to_class_name(source) == expected


### PR DESCRIPTION
## Description

This is **PR-a** of a three-PR ratchet that incrementally restores the coverage gate to
80%. It lands new tests for the three smallest/simplest coverage gaps
(`source_downloader.py`, `client/generated_api.py`, shared utils, plus the
`_auto_generate_client` helper in `client/base.py`) and moves `fail_under` from 80 to 60
so the gate matches the actual coverage this PR produces.

**Why `fail_under` goes down here:** The threshold has been wedged at 80 since the
pyproject-template migration (#3, PR #4) while actual coverage sat at 52.26%. That means
CI has been failing on every run. Rather than land one giant test-everything PR, the
plan in issue #6 (see
[comment](https://github.com/endavis/opnsense-openapi/issues/6#issuecomment-4281725367))
breaks the restoration into three PRs that each bump the floor to match real coverage:

| PR  | Target modules                                           | `fail_under` |
| :-: | :------------------------------------------------------- | :----------: |
| a   | `source_downloader`, `client/generated_api`, utils, helper | **60**     |
| b   | `client/base`, `generator/openapi_generator`             | ~75          |
| c   | `cli.py`, `openapi.py` (largest remaining gaps)          | **80**       |

This PR takes coverage from **52.26% → 60.11%** and sets `fail_under = 60` so the gate
reflects reality. PR-b and PR-c will ratchet it back up to 80.

## Related Issue

Addresses #6

## Type of Change

- [x] Test improvement

## Changes Made

- **`pyproject.toml`**: `[tool.coverage.report] fail_under` lowered from 80 to 60 (one
  line) so the gate matches the coverage this PR produces; subsequent ratchet PRs will
  raise it back.
- **`tests/conftest.py`** (new): Shared fixtures for the new test modules.
- **`tests/test_source_downloader.py`** (new): 16 tests covering
  `downloader/source_downloader.py` (19% → 100%).
- **`tests/test_generated_api.py`** (new): 13 tests covering
  `client/generated_api.py` (33% → 100%).
- **`tests/test_utils.py`** (new): Parametrized tests for `validate_version`,
  `to_snake_case`, and `to_class_name` in `utils.py` (→ 100%).
- **`tests/test_client_auto_generate.py`** (new): 5 tests for the
  `_auto_generate_client` module-level helper in `client/base.py`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`uv run doit check` output:

```
Required test coverage of 60.0% reached. Total coverage: 60.11%
======================= 129 passed, 10 warnings in 2.39s =======================
✓ All checks passed!
```

Per-module coverage after this PR:

| Module                                  | Before | After   |
| :-------------------------------------- | :----: | :-----: |
| `downloader/source_downloader.py`       | 19%    | 100.00% |
| `client/generated_api.py`               | 33%    | 100.00% |
| `utils.py`                              | —      | 100.00% |
| `client/base.py`                        | 46%    | 58.85%  |
| **Total**                               | 52.26% | **60.11%** |

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — N/A (tests + threshold only, no
  behavior or public-API changes; docs that cite 80% describe the ongoing target, which
  this ratchet is moving toward)
- [ ] I have updated the CHANGELOG.md — N/A (chore, generated by commitizen on release)
- [x] My changes generate no new warnings

## Additional Notes

- No ADR required: issue is labeled `chore` with no `needs-adr` label
  (per AGENTS.md: "Doc and chore issues do not need ADRs").
- No public API or user-facing behavior changes in this PR.
- Follow-up PRs (PR-b, PR-c) will continue the ratchet until `fail_under = 80`.
