### PR TITLE
chore: sync repo_settings.py and codeql workflow for manage.py repo

### DIFF
--- a/.config/pyproject_template/settings.toml
+++ b/.config/pyproject_template/settings.toml
@@ -1,3 +1,3 @@
 [template]
-commit = "652bb6ea675d1a6e359cced3ae2c872cbf7c0914"
-commit_date = "2026-04-18"
+commit = "446866f4f628a39672861ed3662f4e6d2842dc76"
+commit_date = "2026-04-21"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,70 @@
+name: CodeQL
+
+# Advanced CodeQL setup (replaces GitHub's "default setup").
+#
+# The summary job below is named exactly `CodeQL` (case-sensitive): that
+# string is the required check-run that branch protection on main expects.
+# If this job is renamed, PRs will stop merging until the ruleset is updated.
+# See issue #431 for the migration from default setup to this workflow.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan, Monday 04:27 UTC. Offset from mutation.yml (Sun 00:00) and
+    # dependabot-automerge.yml (every 6h) so they don't contend for runners.
+    - cron: '27 4 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  CodeQL:
+    # Summary job -- this is the check-run required by the `main` ruleset.
+    # The name MUST be exactly `CodeQL` (case-sensitive) to match branch
+    # protection; renaming it will break merges.
+    name: CodeQL
+    needs: [analyze]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate matrix result
+        env:
+          ANALYZE_RESULT: ${{ needs.analyze.result }}
+        run: |
+          echo "analyze job result: $ANALYZE_RESULT"
+          if [[ "$ANALYZE_RESULT" != "success" ]]; then
+            echo "CodeQL analysis did not succeed for all languages"
+            exit 1
+          fi
+          echo "CodeQL analysis succeeded for all matrix languages"

--- a/tools/pyproject_template/manage.py
+++ b/tools/pyproject_template/manage.py
@@ -430,11 +430,12 @@ def action_create_project(manager: SettingsManager, dry_run: bool, *, yes: bool 
             )
             subprocess.run(["git", "push"], cwd=project_dir, check=True)
 
-        # Now configure branch protection and other GitHub settings
+        # Now configure branch protection and other GitHub settings.
+        # CodeQL scanning is NOT set up here: it runs from the committed
+        # .github/workflows/codeql.yml workflow that was cloned with the repo.
         setup.configure_branch_protection()
         setup.replicate_labels()
         setup.enable_github_pages()
-        setup.configure_codeql()
 
         setup.print_manual_steps()
 
@@ -524,7 +525,6 @@ def action_repo_settings(manager: SettingsManager, dry_run: bool) -> int:
         Logger.info("  - Branch protection rulesets")
         Logger.info("  - Labels")
         Logger.info("  - GitHub Pages")
-        Logger.info("  - CodeQL code scanning")
         return 0
 
     # Import repo_settings module for repository configuration

--- a/tools/pyproject_template/repo_settings.py
+++ b/tools/pyproject_template/repo_settings.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""
+repo_settings.py - GitHub repository settings configuration.
+
+This module provides functions to configure GitHub repository settings,
+branch protection, labels, and GitHub Pages. It can be used independently
+of the full setup process.
+
+CodeQL scanning is configured via the committed workflow file at
+``.github/workflows/codeql.yml`` (advanced setup) -- no API call is
+required, because the workflow is replicated by the template generator
+along with all other workflow files. See issue #431.
+
+These functions are used by both setup_repo.py (initial setup) and
+manage.py (updating existing repositories).
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+from typing import Any
+
+# Support running as script or as module
+_script_dir = Path(__file__).parent
+if str(_script_dir) not in sys.path:
+    sys.path.insert(0, str(_script_dir))
+
+from utils import TEMPLATE_REPO, GitHubCLI, Logger  # noqa: E402
+
+
+def configure_repository_settings(
+    repo_full: str,
+    description: str,
+    visibility: str | None = None,
+    template_repo: str = TEMPLATE_REPO,
+) -> bool:
+    """Configure repository settings to match template.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+        description: Repository description
+        visibility: Repository visibility ('public' or 'private'), used for
+                   determining which security features are available
+        template_repo: Template repository to copy settings from
+
+    Returns:
+        True if successful, False otherwise
+    """
+    Logger.step("Configuring repository settings...")
+
+    try:
+        # Get ALL settings from template repository
+        template_settings = GitHubCLI.api(f"repos/{template_repo}")
+
+        # Read-only fields that should not be copied
+        readonly_fields = {
+            # URLs
+            "archive_url",
+            "assignees_url",
+            "blobs_url",
+            "branches_url",
+            "clone_url",
+            "collaborators_url",
+            "comments_url",
+            "commits_url",
+            "compare_url",
+            "contents_url",
+            "contributors_url",
+            "deployments_url",
+            "downloads_url",
+            "events_url",
+            "forks_url",
+            "git_commits_url",
+            "git_refs_url",
+            "git_tags_url",
+            "git_url",
+            "hooks_url",
+            "html_url",
+            "issue_comment_url",
+            "issue_events_url",
+            "issues_url",
+            "keys_url",
+            "labels_url",
+            "languages_url",
+            "merges_url",
+            "milestones_url",
+            "notifications_url",
+            "pulls_url",
+            "releases_url",
+            "ssh_url",
+            "stargazers_url",
+            "statuses_url",
+            "subscribers_url",
+            "subscription_url",
+            "svn_url",
+            "tags_url",
+            "teams_url",
+            "trees_url",
+            "url",
+            # IDs and metadata
+            "id",
+            "node_id",
+            "owner",
+            "full_name",
+            "name",
+            # Timestamps
+            "created_at",
+            "updated_at",
+            "pushed_at",
+            # Counts and computed values
+            "forks",
+            "forks_count",
+            "open_issues",
+            "open_issues_count",
+            "size",
+            "stargazers_count",
+            "watchers",
+            "watchers_count",
+            "subscribers_count",
+            "network_count",
+            # Other read-only
+            "fork",
+            "language",
+            "license",
+            "permissions",
+            "disabled",
+            "mirror_url",
+            "default_branch",  # Keep as main
+            "private",  # Set separately via visibility
+            "is_template",  # Don't make new repos templates
+            # Deprecated
+            "use_squash_pr_title_as_default",
+        }
+
+        # Build settings data by copying all writable fields from template
+        data: dict[str, Any] = {}
+        for key, value in template_settings.items():
+            if key not in readonly_fields and value is not None:
+                data[key] = value
+
+        # Override description with user's description
+        data["description"] = description
+
+        # Check if repository is in an organization
+        repo_owner = repo_full.split("/")[0]
+        owner_info = GitHubCLI.api(f"users/{repo_owner}")
+        is_org = owner_info.get("type") == "Organization"
+
+        # Remove allow_forking if not an org repo (only applies to orgs)
+        if not is_org and "allow_forking" in data:
+            data.pop("allow_forking")
+
+        # Remove security_and_analysis - we'll handle it separately
+        security_settings = data.pop("security_and_analysis", None)
+
+        # Apply all settings in one call
+        GitHubCLI.api(f"repos/{repo_full}", method="PATCH", data=data)
+        Logger.success("Repository settings configured")
+
+        # Configure security and analysis settings separately
+        if security_settings:
+            _configure_security_settings(repo_full, security_settings, visibility)
+
+        return True
+
+    except subprocess.CalledProcessError as e:
+        Logger.warning("Repository settings configuration failed")
+        if e.stderr:
+            print(f"  Error: {e.stderr.strip()}")
+        Logger.info("You can configure settings manually at:")
+        Logger.info(f"  https://github.com/{repo_full}/settings")
+        return False
+
+
+def _configure_security_settings(
+    repo_full: str,
+    security_settings: dict[str, Any],
+    visibility: str | None = None,
+) -> None:
+    """Configure security and analysis settings.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+        security_settings: Security settings from template
+        visibility: Repository visibility for determining feature availability
+    """
+    if not security_settings:
+        return
+
+    # Enable secret scanning if template has it
+    if security_settings.get("secret_scanning", {}).get("status") == "enabled":
+        try:
+            GitHubCLI.api(
+                f"repos/{repo_full}/secret-scanning",
+                method="PATCH",
+                data={"status": "enabled"},
+            )
+            Logger.success("Secret scanning enabled")
+        except subprocess.CalledProcessError as e:
+            # 404 is expected for free/private repos that don't support this
+            if "404" in str(e.stderr):
+                if visibility == "public":
+                    Logger.success("Secret scanning enabled (default for public repos)")
+                else:
+                    Logger.info("Secret scanning not available (requires GHAS or public repo)")
+            else:
+                Logger.warning("Secret scanning configuration failed")
+                if e.stderr:
+                    print(f"  Error: {e.stderr.strip()}")
+
+    # Enable secret scanning push protection if template has it
+    if security_settings.get("secret_scanning_push_protection", {}).get("status") == "enabled":
+        try:
+            GitHubCLI.api(
+                f"repos/{repo_full}/secret-scanning/push-protection",
+                method="PATCH",
+                data={"status": "enabled"},
+            )
+            Logger.success("Secret scanning push protection enabled")
+        except subprocess.CalledProcessError as e:
+            if "404" in str(e.stderr):
+                if visibility == "public":
+                    Logger.success(
+                        "Secret scanning push protection enabled (default for public repos)"
+                    )
+                else:
+                    Logger.info("Secret scanning push protection not available for this repository")
+            else:
+                Logger.warning("Secret scanning push protection configuration failed")
+                if e.stderr:
+                    print(f"  Error: {e.stderr.strip()}")
+
+    # Enable Dependabot security updates if template has it
+    if security_settings.get("dependabot_security_updates", {}).get("status") == "enabled":
+        try:
+            GitHubCLI.api(
+                f"repos/{repo_full}/automated-security-fixes",
+                method="PUT",
+            )
+            Logger.success("Dependabot security updates enabled")
+        except subprocess.CalledProcessError as e:
+            Logger.warning("Dependabot security updates configuration failed")
+            if e.stderr:
+                print(f"  Error: {e.stderr.strip()}")
+
+
+def configure_branch_protection(
+    repo_full: str,
+    template_repo: str = TEMPLATE_REPO,
+) -> bool:
+    """Configure branch protection using rulesets.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+        template_repo: Template repository to copy rulesets from
+
+    Returns:
+        True if successful, False otherwise
+    """
+    Logger.step("Configuring branch protection rulesets...")
+
+    try:
+        # Get rulesets from template
+        template_rulesets = GitHubCLI.api(f"repos/{template_repo}/rulesets")
+
+        if not template_rulesets:
+            Logger.warning("No rulesets found in template repository")
+            return True  # Not a failure, just nothing to do
+
+        # Get existing rulesets from target repository to check for duplicates
+        existing_rulesets = GitHubCLI.api(f"repos/{repo_full}/rulesets")
+        existing_by_name: dict[str, int] = {
+            ruleset["name"]: ruleset["id"] for ruleset in existing_rulesets
+        }
+
+        # Replicate each ruleset
+        for template_ruleset in template_rulesets:
+            # Get full ruleset details
+            ruleset_id = template_ruleset["id"]
+            full_ruleset = GitHubCLI.api(f"repos/{template_repo}/rulesets/{ruleset_id}")
+
+            # Prepare ruleset data (remove read-only fields)
+            ruleset_data = {
+                "name": full_ruleset["name"],
+                "target": full_ruleset["target"],
+                "enforcement": full_ruleset["enforcement"],
+                "bypass_actors": full_ruleset.get("bypass_actors", []),
+                "conditions": full_ruleset.get("conditions", {}),
+                "rules": full_ruleset.get("rules", []),
+            }
+
+            ruleset_name = full_ruleset["name"]
+
+            # Check if ruleset already exists
+            if ruleset_name in existing_by_name:
+                # Update existing ruleset
+                existing_id = existing_by_name[ruleset_name]
+                GitHubCLI.api(
+                    f"repos/{repo_full}/rulesets/{existing_id}",
+                    method="PUT",
+                    data=ruleset_data,
+                )
+                Logger.success(f"Ruleset '{ruleset_name}' updated")
+            else:
+                # Create new ruleset
+                GitHubCLI.api(
+                    f"repos/{repo_full}/rulesets",
+                    method="POST",
+                    data=ruleset_data,
+                )
+                Logger.success(f"Ruleset '{ruleset_name}' created")
+
+        return True
+
+    except subprocess.CalledProcessError as e:
+        Logger.warning("Branch protection ruleset configuration failed")
+        if e.stderr:
+            print(f"  Error: {e.stderr.strip()}")
+        Logger.info("You can configure rulesets manually at:")
+        Logger.info(f"  https://github.com/{repo_full}/settings/rules")
+        return False
+
+
+def replicate_labels(
+    repo_full: str,
+    template_repo: str = TEMPLATE_REPO,
+) -> bool:
+    """Replicate labels from template.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+        template_repo: Template repository to copy labels from
+
+    Returns:
+        True if successful, False otherwise
+    """
+    Logger.step("Replicating labels from template...")
+
+    try:
+        # Get labels from template
+        labels = GitHubCLI.api(f"repos/{template_repo}/labels")
+
+        if not labels:
+            Logger.warning("Could not retrieve labels from template")
+            return False
+
+        # Create each label
+        for label in labels:
+            try:
+                label_data = {
+                    "name": label["name"],
+                    "color": label["color"],
+                    "description": label.get("description", ""),
+                }
+                GitHubCLI.api(
+                    f"repos/{repo_full}/labels",
+                    method="POST",
+                    data=label_data,
+                )
+            except subprocess.CalledProcessError:
+                # Label might already exist, skip
+                pass
+
+        Logger.success("Labels replicated")
+        return True
+
+    except subprocess.CalledProcessError as e:
+        Logger.warning("Failed to retrieve labels from template")
+        if e.stderr:
+            print(f"  Error: {e.stderr.strip()}")
+        return False
+
+
+def enable_github_pages(repo_full: str) -> bool:
+    """Enable GitHub Pages.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+
+    Returns:
+        True if successful, False otherwise
+    """
+    Logger.step("Enabling GitHub Pages...")
+
+    try:
+        data = {
+            "source": {
+                "branch": "gh-pages",
+                "path": "/",
+            }
+        }
+        GitHubCLI.api(f"repos/{repo_full}/pages", method="POST", data=data)
+        Logger.success("GitHub Pages enabled")
+        return True
+    except subprocess.CalledProcessError:
+        Logger.warning("GitHub Pages not enabled (gh-pages branch doesn't exist yet)")
+        Logger.info("Pages will be enabled automatically after first docs deployment")
+        return False
+
+
+def update_all_repo_settings(
+    repo_full: str,
+    description: str,
+    visibility: str | None = None,
+    template_repo: str = TEMPLATE_REPO,
+) -> bool:
+    """Update all repository settings to match template.
+
+    This is a convenience function that runs all configuration steps.
+
+    Note: CodeQL scanning is NOT configured here -- it is driven by the
+    committed ``.github/workflows/codeql.yml`` workflow file, which the
+    template generator copies into new repositories alongside every other
+    workflow. No API call is required. See issue #431.
+
+    Args:
+        repo_full: Full repository name (owner/repo)
+        description: Repository description
+        visibility: Repository visibility ('public' or 'private')
+        template_repo: Template repository to copy settings from
+
+    Returns:
+        True if all steps successful, False if any failed
+    """
+    results = [
+        configure_repository_settings(repo_full, description, visibility, template_repo),
+        configure_branch_protection(repo_full, template_repo),
+        replicate_labels(repo_full, template_repo),
+        enable_github_pages(repo_full),
+    ]
+    return all(results)


### PR DESCRIPTION
## Description

Syncs the three template files required to make `manage.py repo` loadable
so the post-merge step of issue #8 can configure branch protection, repo
settings, labels, and Pages via the GitHub API.

Currently `manage.py repo` fails with `ImportError: repo_settings` because
`repo_settings.py` was never copied during the initial template migration
(#3 / PR #4), and the main branch is unprotected server-side
(`gh api repos/endavis/opnsense-openapi/branches/main/protection` → 404).

This PR does **not** apply any repo settings itself. `manage.py repo`
makes GitHub API calls and cannot live in a commit -- it is a manual
post-merge step (see below).

## Related Issue

Addresses #8

## Type of Change

- [x] Code refactoring

(Chore-class change -- syncs tooling files from the upstream
`pyproject-template`. No runtime behavior change for users of this
project's generated wrapper.)

## Changes Made

Three working-tree files, all byte-identical copies of upstream
`pyproject-template@446866f4`:

- **NEW** `tools/pyproject_template/repo_settings.py` — required by
  `manage.py repo`. Provides `configure_repository_settings`,
  `configure_branch_protection`, `replicate_labels`,
  `enable_github_pages`, `update_all_repo_settings`.
- **MODIFIED** `tools/pyproject_template/manage.py` — synced from
  upstream. Drops `setup.configure_codeql()` from
  `action_create_project` and removes the matching dry-run bullet.
  CodeQL now lives entirely in the committed workflow file.
- **NEW** `.github/workflows/codeql.yml` — advanced CodeQL workflow
  with a summary job named exactly `CodeQL` that the planned `main`
  ruleset's `code_scanning` rule references. Runs on push to `main`,
  PR to `main`, and a weekly schedule.

Plus the already-committed sync-state bump
(`01dc37a chore: sync template state to 446866f4…`) updating
`.config/pyproject_template/settings.toml`.

## Testing

- [x] All existing tests pass (`doit check` -- format_check, lint,
      type_check, security, spell_check, test all green)
- [x] Verified `repo_settings.py`, `manage.py`, and `codeql.yml` are
      byte-identical to upstream
      (`/home/endavis/src/pyproject-template/`)
- [x] Confirmed `configure_codeql` is absent from the synced
      `repo_settings.py` (grep: no matches) -- consistent with the
      call being removed from `manage.py`
- [x] Confirmed `settings.toml` on branch contains
      `commit = "446866f4f628a39672861ed3662f4e6d2842dc76"`
      and `commit_date = "2026-04-21"`
- [ ] Added new tests for new functionality — N/A, template-tool files
      follow upstream test surface and are not exercised by this
      project's test suite
- [x] Manually tested `doit check`

## Scope clarifications

- This PR does **not** run `manage.py repo`. That step applies GitHub
  settings via API and is performed manually after merge.
- This PR does **not** repopulate `.config/pyproject_template/settings.toml`
  with `description`, `github_user`, `github_repo`, etc. The plan
  originally called for running `manage.py configure` to backfill those,
  but `configure` is a one-shot bootstrap action and is destructive when
  re-run on an already-configured project. Instead, `SettingsManager`
  auto-derives these fields at runtime from `pyproject.toml` and
  `git remote` (see `tools/pyproject_template/settings.py:242-305`), so
  no backfill is needed. Verified locally: description resolves to
  `"OpenAPI-based Python client for OPNsense with bundled specs"`
  (from `pyproject.toml`), `github_user` to `endavis`, `github_repo`
  to `opnsense-openapi`.
- **Heads-up:** when `manage.py repo` runs post-merge, it will PATCH
  the GitHub repo description from its current value
  (`"a python interface for the MVC opnsense API"`) to the pyproject
  value above. This is expected and aligns with the template's intent
  that `pyproject.toml` is the source of truth.

## Post-merge steps (for reference — not part of this PR)

```bash
# 1. Dry-run: verifies the tool loads and prints planned actions
uv run python tools/pyproject_template/manage.py repo --dry-run

# 2. Apply repo + ruleset + labels + Pages attempt
uv run python tools/pyproject_template/manage.py repo
```

Expected effects when run:

- PATCH repo: flips `has_wiki` (true→false),
  `allow_merge_commit` (true→false), `allow_rebase_merge` (true→false),
  `allow_auto_merge` (false→true),
  `delete_branch_on_merge` (false→true).
- POST new `main` ruleset (no existing ruleset → create): deletion,
  non-fast-forward, creation, required linear history, required
  signatures, pull request (squash-only, 0 approvers, dismiss stale,
  require thread resolution), code scanning (CodeQL
  errors / high-or-higher), code quality (errors), required status
  checks (`require-label`, strict). Bypass actor: Admin role.
- Replicate labels: all 21 template labels already exist → silent
  no-op.
- Enable Pages: no `gh-pages` branch exists → silent warning. See
  follow-up below.

## Known drift / follow-ups (not in scope here)

- **Wider template sync:** `manage.py check` reports 96+ files differ
  from upstream `446866f4`. This PR only syncs the 3 files required
  for `manage.py repo`. A broader template re-sync is a separate
  chore.
- **`gh-pages` branch + docs deploy workflow:** `enable_github_pages`
  has no source to attach to. Needs a dedicated issue to add a
  `gh-pages` branch and a docs-deploy workflow.
- **CodeQL alert triage:** `codeql.yml` will run for the first time on
  this PR. If it surfaces alerts, triage is a follow-up issue.
- **Stale doc references to `configure_codeql()`:** three doc files
  still mention the removed function
  (`docs/template/tools-reference.md`, `docs/template/manage.md`,
  `docs/development/github-repository-settings.md`). Intentionally
  left alone here to keep this PR minimal and chore-scoped; fold into
  the wider template sync.
- **Upstream `manage.py configure` is destructive on re-run:** when
  run against an already-configured project, it "re-templates"
  placeholder-looking values (e.g., rewrites the OpenAPI generator
  key `package_name_override` to `opnsense_openapi_override`) and
  self-deletes `configure.py`. Upstream docs describe it as
  re-runnable; behavior disagrees. Worth filing upstream.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`
      via `doit check`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my
      feature works — N/A (template-tool files, no new project
      behavior)
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — see follow-up
      note above re: stale doc references
- [ ] I have updated the CHANGELOG.md — N/A, changelog is
      commitizen-generated at release time
- [x] My changes generate no new warnings

## Additional Notes

Verified ruleset preconditions per the implementation plan on #8:

- Latest `main` commit is `verified: true` on GitHub → the
  `required_signatures` rule will accept signed commits going forward.
  Older unsigned commits on `main` aren't retroactively rejected.
- The ruleset's only *required status check* is `require-label`,
  which already exists in `.github/workflows/pr-checks.yml`.
- `code_scanning` rule checks alert *severity*, not a status check --
  so zero alerts = nothing blocks merges.
