### PR TITLE
chore: adopt template logging.py and benchmarks scaffolding

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -74,3 +74,12 @@ Downloads upstream OPNsense source archives used during spec generation.
     options:
       show_root_heading: true
       show_root_full_path: true
+
+## Logging
+
+Centralized logging configuration shared by the CLI and library code.
+
+::: opnsense_openapi.logging
+    options:
+      show_root_heading: true
+      show_root_full_path: true

--- a/src/opnsense_openapi/cli.py
+++ b/src/opnsense_openapi/cli.py
@@ -15,6 +15,7 @@ from .downloader import SourceDownloader
 # ENFORCE: Ensure your generator file is named 'generator.py'
 # or update this import to 'from .openapi_generator import OpenApiGenerator'
 from .generator import OpenApiGenerator
+from .logging import LogLevel, setup_logging
 from .parser import ControllerParser
 from .specs import find_best_matching_spec, list_available_specs
 from .validator import SpecValidator
@@ -39,8 +40,26 @@ def main(
             callback=_version_callback,
         ),
     ] = False,
+    log_level: Annotated[
+        LogLevel | None,
+        typer.Option(
+            "--log-level",
+            help=(
+                "Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL). "
+                "Defaults to INFO, or DEBUG if the DEBUG env var is set."
+            ),
+        ),
+    ] = None,
+    log_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--log-file",
+            help="Optional path for structured JSON log output.",
+        ),
+    ] = None,
 ) -> None:
     """Global CLI options."""
+    setup_logging(level=log_level, log_file=log_file)
 
 
 @app.command()

--- a/src/opnsense_openapi/logging.py
+++ b/src/opnsense_openapi/logging.py
@@ -1,0 +1,147 @@
+"""Logging configuration for opnsense_openapi.
+
+This module provides a centralized logging setup with:
+- ISO8601 timestamps for all log entries
+- Simple console output for human readability
+- Structured JSON file output for machine processing
+"""
+
+import json
+import logging
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+
+
+class SimpleConsoleFormatter(logging.Formatter):
+    """Simple formatter for console output with ISO8601 timestamps."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format log record with simple output.
+
+        Args:
+            record: The log record to format
+
+        Returns:
+            Formatted log string: "LEVEL: message"
+        """
+        return f"{record.levelname}: {record.getMessage()}"
+
+
+class StructuredFileFormatter(logging.Formatter):
+    """Structured JSON formatter for file output with ISO8601 timestamps."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format log record as JSON with ISO8601 timestamp.
+
+        Args:
+            record: The log record to format
+
+        Returns:
+            JSON-formatted log string with timestamp, level, message, and metadata
+        """
+        log_data: dict[str, Any] = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "module": record.module,
+            "function": record.funcName,
+            "line": record.lineno,
+        }
+
+        # Add exception info if present
+        if record.exc_info:
+            log_data["exception"] = self.formatException(record.exc_info)
+
+        # Add extra fields if present
+        if hasattr(record, "extra_fields"):
+            log_data["extra"] = record.extra_fields
+
+        return json.dumps(log_data)
+
+
+def setup_logging(
+    level: LogLevel | None = None,
+    log_file: str | Path | None = None,
+    console: bool = True,
+) -> logging.Logger:
+    """Configure logging for the application.
+
+    Sets up logging with:
+    - Simple console output (if enabled)
+    - Structured JSON file output (if log_file specified)
+    - ISO8601 timestamps for all entries
+
+    Args:
+        level: Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+               Defaults to INFO, or DEBUG if DEBUG environment variable is set.
+        log_file: Optional file path for structured JSON logging.
+                  If provided, creates parent directories if needed.
+        console: Enable console logging. Defaults to True.
+
+    Returns:
+        Configured root logger
+
+    Examples:
+        Basic console logging:
+        >>> setup_logging()
+        <Logger root (INFO)>
+
+        Console and file logging:
+        >>> setup_logging(level="DEBUG", log_file="app.log")
+        <Logger root (DEBUG)>
+
+        File logging only:
+        >>> setup_logging(console=False, log_file="app.log")
+        <Logger root (INFO)>
+    """
+    # Determine log level - ensure it's never None
+    resolved_level: LogLevel = (
+        level if level is not None else ("DEBUG" if os.getenv("DEBUG") else "INFO")
+    )
+
+    # Get root logger and clear existing handlers
+    root_logger = logging.getLogger()
+    root_logger.setLevel(getattr(logging, resolved_level))
+    root_logger.handlers.clear()
+
+    # Add console handler with simple formatting
+    if console:
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setLevel(getattr(logging, resolved_level))
+        console_handler.setFormatter(SimpleConsoleFormatter())
+        root_logger.addHandler(console_handler)
+
+    # Add file handler with structured JSON formatting
+    if log_file:
+        log_path = Path(log_file)
+        # Create parent directories if they don't exist
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        file_handler = logging.FileHandler(log_path)
+        file_handler.setLevel(getattr(logging, resolved_level))
+        file_handler.setFormatter(StructuredFileFormatter())
+        root_logger.addHandler(file_handler)
+
+    return root_logger
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Get a logger instance for a module.
+
+    Args:
+        name: Logger name (typically __name__ of the module)
+
+    Returns:
+        Logger instance
+
+    Examples:
+        >>> logger = get_logger(__name__)
+        >>> logger.info("Application started")
+    """
+    return logging.getLogger(name)

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,6 @@
+"""Benchmark test configuration.
+
+Benchmark marker is registered in pyproject.toml under [tool.pytest.ini_options].
+Benchmarks are disabled by default (--benchmark-disable in addopts).
+Use `doit benchmark` to run with --benchmark-enable.
+"""

--- a/tests/benchmarks/test_bench_generator.py
+++ b/tests/benchmarks/test_bench_generator.py
@@ -1,0 +1,79 @@
+"""Benchmark tests for OpenApiGenerator.generate.
+
+Builds a small in-memory list of ApiController/ApiEndpoint instances and
+measures how long the generator takes to assemble and serialize an OpenAPI
+spec to disk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opnsense_openapi.generator.openapi_generator import OpenApiGenerator
+from opnsense_openapi.parser import ApiController, ApiEndpoint
+
+
+def _make_controllers() -> list[ApiController]:
+    """Return a small set of synthetic controllers covering common HTTP shapes."""
+    modules: tuple[tuple[str, str], ...] = (
+        ("Firewall", "Alias"),
+        ("Firewall", "Filter"),
+        ("System", "Info"),
+        ("System", "Settings"),
+        ("Diagnostics", "Interface"),
+        ("Diagnostics", "Routes"),
+    )
+    controllers: list[ApiController] = []
+    for module, controller in modules:
+        endpoints = [
+            ApiEndpoint(
+                name="find",
+                method="POST",
+                description=f"Find {controller} entries",
+                parameters=[],
+            ),
+            ApiEndpoint(
+                name="get",
+                method="GET",
+                description=f"Get {controller}",
+                parameters=["uuid"],
+            ),
+            ApiEndpoint(
+                name="add",
+                method="POST",
+                description=f"Add {controller}",
+                parameters=[],
+            ),
+            ApiEndpoint(
+                name="set",
+                method="POST",
+                description=f"Update {controller}",
+                parameters=["uuid"],
+            ),
+        ]
+        controllers.append(
+            ApiController(
+                module=module,
+                controller=controller,
+                base_class="ApiControllerBase",
+                endpoints=endpoints,
+                model_class=None,
+            )
+        )
+    return controllers
+
+
+@pytest.fixture
+def controllers() -> list[ApiController]:
+    """Provide a small set of ApiController instances for benchmarking."""
+    return _make_controllers()
+
+
+@pytest.mark.benchmark
+def test_bench_generate_spec(benchmark, tmp_path: Path, controllers: list[ApiController]) -> None:
+    """Benchmark generating an OpenAPI spec from synthetic controllers."""
+    generator = OpenApiGenerator(tmp_path)
+    spec_path = benchmark(generator.generate, controllers, "24.7")
+    assert spec_path.exists()

--- a/tests/benchmarks/test_bench_parser.py
+++ b/tests/benchmarks/test_bench_parser.py
@@ -1,0 +1,104 @@
+"""Benchmark tests for ControllerParser.parse_directory.
+
+These benchmarks build a small synthetic tree of OPNsense-style PHP controller
+files in a tmp_path and measure how long it takes the parser to walk the tree
+and extract endpoints.
+
+Inputs are intentionally small (a handful of controllers) so each benchmark
+finishes in well under a second.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opnsense_openapi.parser import ControllerParser
+
+# Modules used to lay out a realistic-but-small controller directory.
+_MODULES: tuple[tuple[str, str], ...] = (
+    ("Firewall", "Alias"),
+    ("Firewall", "Filter"),
+    ("System", "Info"),
+    ("System", "Settings"),
+    ("Diagnostics", "Interface"),
+    ("Diagnostics", "Routes"),
+    ("Interfaces", "Vlan"),
+    ("Interfaces", "Loopback"),
+)
+
+
+def _controller_php(module: str, controller: str) -> str:
+    """Return a minimal but realistic OPNsense-style controller PHP source."""
+    return f"""<?php
+namespace OPNsense\\{module}\\Api;
+
+use OPNsense\\Base\\ApiControllerBase;
+
+/**
+ * Class {controller}Controller
+ */
+class {controller}Controller extends ApiControllerBase
+{{
+    /**
+     * Find {controller} entries
+     * @return array
+     */
+    public function findAction()
+    {{
+        return $this->searchBase("{controller.lower()}", $this->request->getPost());
+    }}
+
+    /**
+     * Get a single {controller}
+     * @param string $uuid
+     * @return array
+     */
+    public function getAction($uuid)
+    {{
+        return $this->getBase("{controller.lower()}", "field", $uuid);
+    }}
+
+    /**
+     * Add a new {controller}
+     * @return array
+     */
+    public function addAction()
+    {{
+        return $this->addBase("{controller.lower()}");
+    }}
+
+    /**
+     * Update {controller} settings
+     * @param string $uuid
+     * @return array
+     */
+    public function setAction($uuid)
+    {{
+        return $this->setBase("{controller.lower()}", $uuid);
+    }}
+}}
+"""
+
+
+@pytest.fixture
+def controller_tree(tmp_path: Path) -> Path:
+    """Create a small synthetic OPNsense controllers tree under ``tmp_path``."""
+    for module, controller in _MODULES:
+        api_dir = tmp_path / module / "Api"
+        api_dir.mkdir(parents=True, exist_ok=True)
+        (api_dir / f"{controller}Controller.php").write_text(
+            _controller_php(module, controller),
+            encoding="utf-8",
+        )
+    return tmp_path
+
+
+@pytest.mark.benchmark
+def test_bench_parse_directory(benchmark, controller_tree: Path) -> None:
+    """Benchmark parsing a small synthetic controller directory."""
+    parser = ControllerParser()
+    controllers = benchmark(parser.parse_directory, controller_tree)
+    # Sanity check: the synthetic tree should fully parse.
+    assert len(controllers) == len(_MODULES)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,307 @@
+"""Tests for logging configuration."""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from opnsense_openapi.logging import (
+    SimpleConsoleFormatter,
+    StructuredFileFormatter,
+    get_logger,
+    setup_logging,
+)
+
+
+class TestSimpleConsoleFormatter:
+    """Tests for SimpleConsoleFormatter."""
+
+    def test_format_basic_message(self) -> None:
+        """Test basic message formatting."""
+        formatter = SimpleConsoleFormatter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=10,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+        output = formatter.format(record)
+        assert output == "INFO: Test message"
+
+    def test_format_with_args(self) -> None:
+        """Test message formatting with arguments."""
+        formatter = SimpleConsoleFormatter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.WARNING,
+            pathname="test.py",
+            lineno=10,
+            msg="User %s logged in",
+            args=("alice",),
+            exc_info=None,
+        )
+        output = formatter.format(record)
+        assert output == "WARNING: User alice logged in"
+
+    def test_format_different_levels(self) -> None:
+        """Test formatting with different log levels."""
+        formatter = SimpleConsoleFormatter()
+        levels = [
+            (logging.DEBUG, "DEBUG"),
+            (logging.INFO, "INFO"),
+            (logging.WARNING, "WARNING"),
+            (logging.ERROR, "ERROR"),
+            (logging.CRITICAL, "CRITICAL"),
+        ]
+
+        for level, level_name in levels:
+            record = logging.LogRecord(
+                name="test",
+                level=level,
+                pathname="test.py",
+                lineno=10,
+                msg="Test",
+                args=(),
+                exc_info=None,
+            )
+            output = formatter.format(record)
+            assert output == f"{level_name}: Test"
+
+
+class TestStructuredFileFormatter:
+    """Tests for StructuredFileFormatter."""
+
+    def test_format_basic_message(self) -> None:
+        """Test basic JSON formatting."""
+        formatter = StructuredFileFormatter()
+        record = logging.LogRecord(
+            name="test.module",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=42,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+        record.module = "test"
+        record.funcName = "test_function"
+
+        output = formatter.format(record)
+        data = json.loads(output)
+
+        assert data["level"] == "INFO"
+        assert data["logger"] == "test.module"
+        assert data["message"] == "Test message"
+        assert data["module"] == "test"
+        assert data["function"] == "test_function"
+        assert data["line"] == 42
+
+    def test_format_with_timestamp(self) -> None:
+        """Test that timestamp is in ISO8601 format."""
+        formatter = StructuredFileFormatter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=10,
+            msg="Test",
+            args=(),
+            exc_info=None,
+        )
+        record.module = "test"
+        record.funcName = "test_func"
+
+        output = formatter.format(record)
+        data = json.loads(output)
+
+        # Verify ISO8601 format by parsing it
+        timestamp = datetime.fromisoformat(data["timestamp"])
+        assert isinstance(timestamp, datetime)
+        # Should include timezone info
+        assert data["timestamp"].endswith("+00:00") or data["timestamp"].endswith("Z")
+
+    def test_format_with_exception(self) -> None:
+        """Test formatting with exception information."""
+        formatter = StructuredFileFormatter()
+
+        try:
+            raise ValueError("Test error")
+        except ValueError:
+            import sys
+
+            exc_info = sys.exc_info()
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=10,
+            msg="Error occurred",
+            args=(),
+            exc_info=exc_info,
+        )
+        record.module = "test"
+        record.funcName = "test_func"
+
+        output = formatter.format(record)
+        data = json.loads(output)
+
+        assert data["level"] == "ERROR"
+        assert data["message"] == "Error occurred"
+        assert "exception" in data
+        assert "ValueError: Test error" in data["exception"]
+        assert "Traceback" in data["exception"]
+
+
+class TestSetupLogging:
+    """Tests for setup_logging function."""
+
+    def test_default_setup(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test default logging setup (console only, INFO level)."""
+        logger = setup_logging()
+
+        assert logger == logging.getLogger()
+        assert logger.level == logging.INFO
+        assert len(logger.handlers) == 1
+        assert isinstance(logger.handlers[0], logging.StreamHandler)
+
+    def test_custom_level(self) -> None:
+        """Test setting custom log level."""
+        logger = setup_logging(level="DEBUG")
+        assert logger.level == logging.DEBUG
+
+        logger = setup_logging(level="WARNING")
+        assert logger.level == logging.WARNING
+
+    def test_debug_environment_variable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test DEBUG environment variable sets debug level."""
+        monkeypatch.setenv("DEBUG", "1")
+        logger = setup_logging()
+        assert logger.level == logging.DEBUG
+
+    def test_console_disabled(self) -> None:
+        """Test disabling console logging."""
+        logger = setup_logging(console=False)
+        assert len(logger.handlers) == 0
+
+    def test_file_logging(self, tmp_path: Path) -> None:
+        """Test file logging setup."""
+        log_file = tmp_path / "test.log"
+        logger = setup_logging(log_file=log_file)
+
+        # Should have both console and file handlers
+        assert len(logger.handlers) == 2
+        file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+        assert len(file_handlers) == 1
+
+        # Test that file is created
+        assert log_file.exists()
+
+    def test_file_logging_creates_directories(self, tmp_path: Path) -> None:
+        """Test that file logging creates parent directories."""
+        log_file = tmp_path / "logs" / "app" / "test.log"
+        setup_logging(log_file=log_file)
+
+        assert log_file.parent.exists()
+        assert log_file.exists()
+
+    def test_file_only_logging(self, tmp_path: Path) -> None:
+        """Test file-only logging (no console)."""
+        log_file = tmp_path / "test.log"
+        logger = setup_logging(console=False, log_file=log_file)
+
+        assert len(logger.handlers) == 1
+        assert isinstance(logger.handlers[0], logging.FileHandler)
+
+    def test_logging_output_console(self, capfd: pytest.CaptureFixture[str]) -> None:
+        """Test console logging output format."""
+        setup_logging(level="INFO")
+        logger = logging.getLogger("test")
+
+        logger.info("Test message")
+
+        captured = capfd.readouterr()
+        assert "INFO: Test message" in captured.out
+
+    def test_logging_output_file(self, tmp_path: Path) -> None:
+        """Test file logging output format."""
+        log_file = tmp_path / "test.log"
+        setup_logging(level="INFO", log_file=log_file, console=False)
+        logger = logging.getLogger("test.module")
+
+        logger.info("Test file message")
+
+        # Read and parse the log file
+        content = log_file.read_text(encoding="utf-8").strip()
+        data = json.loads(content)
+
+        assert data["level"] == "INFO"
+        assert data["message"] == "Test file message"
+        assert data["logger"] == "test.module"
+        assert "timestamp" in data
+        # Verify ISO8601 format
+        datetime.fromisoformat(data["timestamp"])
+
+    def test_multiple_log_entries(self, tmp_path: Path) -> None:
+        """Test multiple log entries are written correctly."""
+        log_file = tmp_path / "test.log"
+        setup_logging(level="DEBUG", log_file=log_file, console=False)
+        logger = logging.getLogger("test")
+
+        logger.debug("Debug message")
+        logger.info("Info message")
+        logger.warning("Warning message")
+        logger.error("Error message")
+
+        # Read all log entries
+        lines = log_file.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 4
+
+        # Parse each line and verify
+        levels = ["DEBUG", "INFO", "WARNING", "ERROR"]
+        for i, line in enumerate(lines):
+            data = json.loads(line)
+            assert data["level"] == levels[i]
+
+    def test_handlers_cleared_on_setup(self) -> None:
+        """Test that existing handlers are cleared when setup is called."""
+        # First setup
+        logger1 = setup_logging()
+        handler_count_1 = len(logger1.handlers)
+
+        # Second setup should clear previous handlers
+        logger2 = setup_logging(level="DEBUG")
+        handler_count_2 = len(logger2.handlers)
+
+        # Should be same logger instance
+        assert logger1 is logger2
+        # Handler count should be the same (old handlers cleared)
+        assert handler_count_1 == handler_count_2
+
+
+class TestGetLogger:
+    """Tests for get_logger function."""
+
+    def test_get_logger_returns_logger(self) -> None:
+        """Test that get_logger returns a Logger instance."""
+        logger = get_logger("test.module")
+        assert isinstance(logger, logging.Logger)
+        assert logger.name == "test.module"
+
+    def test_get_logger_same_instance(self) -> None:
+        """Test that get_logger returns the same instance for the same name."""
+        logger1 = get_logger("test.module")
+        logger2 = get_logger("test.module")
+        assert logger1 is logger2
+
+    def test_get_logger_different_instances(self) -> None:
+        """Test that different names return different loggers."""
+        logger1 = get_logger("module1")
+        logger2 = get_logger("module2")
+        assert logger1 is not logger2
+        assert logger1.name != logger2.name


### PR DESCRIPTION
## Description

Adopts the upstream `pyproject-template` `logging.py` infrastructure plus a working `tests/benchmarks/` directory, wires the new logging module into the Typer CLI callback, and adds a docs entry. Implements the scoped plan attached to issue #15.

This is the second pass at PR #13's deferred template adoption work: instead of taking everything wholesale, we adopt only the pieces that fill a real infrastructure gap and skip the toy/pedagogical files that would shadow project-specific modules.

## Related Issue

Addresses #15

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test improvement

## Changes Made

**Adopted from upstream (`tmp/extracted/pyproject-template-main/`):**

- `src/opnsense_openapi/logging.py` — verbatim copy of `src/package_name/logging.py` with one prose substitution (docstring `package_name` -> `opnsense_openapi`). Provides `LogLevel`, `SimpleConsoleFormatter`, `StructuredFileFormatter`, `setup_logging()`, `get_logger()`. Stdlib only, no new dependencies.
- `tests/test_logging.py` — copied from `tests/test_logging.py` with import path rewrite. 20 tests covering formatters, setup modes, handler config, and env-var handling.
- `tests/benchmarks/__init__.py` and `tests/benchmarks/conftest.py` — adopted from upstream (empty package + docstring noting marker registration and `--benchmark-enable` semantics).

**Project-specific additions:**

- `tests/benchmarks/test_bench_parser.py` — benchmarks `ControllerParser.parse_directory()` against a synthetic 8-controller PHP tree.
- `tests/benchmarks/test_bench_generator.py` — benchmarks `OpenApiGenerator.generate()` against 6 synthetic in-memory `ApiController` instances.

**CLI integration:**

- `src/opnsense_openapi/cli.py` — adds `--log-level` (`LogLevel | None`) and `--log-file` (`Path | None`) options to the `main()` callback and calls `setup_logging(level=log_level, log_file=log_file)`.

**Documentation:**

- `docs/reference/api.md` — appended one mkdocstrings block rendering `opnsense_openapi.logging`.

## What Was Skipped (and why)

Per the plan in issue #15, these upstream files were intentionally not copied:

- `src/package_name/core.py` and `tests/test_core.py` — toy `greet()` scaffolding; the project has its own modules.
- `tests/test_cli.py` (Click-based) — upstream's CLI tests target a Click app, not Typer.
- `tests/test_example.py` — pedagogical tests with no project value.
- `tests/benchmarks/test_bench_core.py` and `tests/benchmarks/test_bench_logging.py` — toy benchmarks of the skipped scaffolding.
- `TestGreetProperties` in `tests/template/test_properties.py` — already omitted in PR #13 because it imports `package_name.core.greet`. Since `core.py` stays unadopted, this deferral is now permanent.

## Behavior Change

The 5 project modules using `logger = logging.getLogger(__name__)` (`generator/openapi_generator.py`, `downloader/source_downloader.py`, `validator.py`, `client/base.py`, `cli.py`) were previously silent because nothing called `logging.basicConfig()`. After this PR, the Typer callback calls `setup_logging()` on every invocation, so existing `logger.info(...)` calls now produce console output by default. Existing `typer.echo()` calls are unchanged. This is the intended improvement — centralized logging was the gap that motivated the adoption.

## Follow-up Required

`tools/pyproject_template/check_template_updates.py` has no per-file exclusion mechanism, so future `manage.py check` runs will keep flagging the deliberately-skipped files (`core.py`, `test_core.py`, `test_cli.py`, `test_example.py`, `test_bench_core.py`, `test_bench_logging.py`) as drift. Adding a project-local exclusion list touches the upstream-template tooling and is a separate design decision; it should be filed as its own issue.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (`tests/test_logging.py`, 2 benchmark files)
- [x] Manually verified `--log-level` / `--log-file` options surface via `--help`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (api.md)
- [ ] I have updated the CHANGELOG.md (handled at release time by commitizen)
- [x] My changes generate no new warnings

## Additional Notes

- No ADR needed: issue #15 has no `needs-adr` label and the plan explicitly states this adopts upstream infrastructure rather than introducing a new architectural pattern.
- Source files for the adopted code live under `tmp/extracted/pyproject-template-main/` for reference.
