### PR TITLE
docs: dissolve mkdocs.yml 'Project' nav section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ opnsense-openapi download <version>
 opnsense-openapi generate <version>
 ```
 
-See [GENERATED_CLIENT_USAGE.md](docs/GENERATED_CLIENT_USAGE.md) for complete documentation.
+See [Generated Client Usage](docs/usage/generated-client.md) for complete documentation.
 
 ## CLI Commands
 

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -14,6 +14,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
 - [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
 - [Examples](examples/README.md) - OPNsense-specific example scripts that ship with this project
+- [Generated Client Usage](usage/generated-client.md) - Use generated OPNsense clients with automatic version detection
 - [GitHub Repository Settings](development/github-repository-settings.md) - Complete reference for all GitHub repository settings the template expects
 - [Installation Guide](getting-started/installation.md) - How to install and set up your project
 - [Keeping Up to Date](template/updates.md) - Stay in sync with improvements to the pyproject-template
@@ -34,6 +35,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
 - [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
 - [API Reference](reference/api.md) - Complete API documentation for opnsense-openapi
+- [Architecture](development/architecture.md) - How the OPNsense OpenAPI generator parses and emits clients
 - [CI/CD Testing Guide](development/ci-cd-testing.md) - GitHub Actions pipelines for testing, linting, and coverage
 - [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
 - [CLI Guide](usage/cli.md) - The application's user-facing command-line interface and how to extend it
@@ -42,10 +44,12 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
 - [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
 - [GitHub Repository Settings](development/github-repository-settings.md) - Complete reference for all GitHub repository settings the template expects
+- [Heuristic Schema Generation](development/heuristics.md) - How the generator infers response schemas when none are declared
 - [Installation Guide](getting-started/installation.md) - How to install and set up your project
 - [opnsense-openapi Documentation](index.md) - Welcome and overview of the project
 - [Optional Extensions](development/extensions.md) - Additional tools and extensions for testing, security, and more
 - [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
+- [Publishing to PyPI](deployment/publishing.md) - Release-time procedure for publishing the package to PyPI
 - [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
 - [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling
 - [Ruff Auto-Fix on Edit Hook](development/ai/ruff-fix-hook.md) - PostToolUse hook that runs ruff --fix on edited Python files
@@ -93,8 +97,8 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
 - [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
 - [API Reference](reference/api.md) - Complete API documentation for opnsense-openapi
+- [Architecture](development/architecture.md) - How the OPNsense OpenAPI generator parses and emits clients
 - [Architecture Decision Records](decisions/README.md)
-- [Architecture Documentation](ARCHITECTURE.md)
 - [CI/CD Testing Guide](development/ci-cd-testing.md) - GitHub Actions pipelines for testing, linting, and coverage
 - [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
 - [CLI Guide](usage/cli.md) - The application's user-facing command-line interface and how to extend it
@@ -103,8 +107,9 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
 - [Examples](examples/README.md) - OPNsense-specific example scripts that ship with this project
 - [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
+- [Generated Client Usage](usage/generated-client.md) - Use generated OPNsense clients with automatic version detection
 - [GitHub Repository Settings](development/github-repository-settings.md) - Complete reference for all GitHub repository settings the template expects
-- [Heuristic Schema Generation Guide](HEURISTICS.md)
+- [Heuristic Schema Generation](development/heuristics.md) - How the generator infers response schemas when none are declared
 - [install_tools Framework](development/install-tools-framework.md)
 - [Installation Guide](getting-started/installation.md) - How to install and set up your project
 - [Keeping Up to Date](template/updates.md) - Stay in sync with improvements to the pyproject-template
@@ -113,7 +118,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [opnsense-openapi Documentation](index.md) - Welcome and overview of the project
 - [Optional Extensions](development/extensions.md) - Additional tools and extensions for testing, security, and more
 - [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
-- [Publishing to PyPI](PUBLISHING.md)
+- [Publishing to PyPI](deployment/publishing.md) - Release-time procedure for publishing the package to PyPI
 - [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
 - [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling
 - [Ruff Auto-Fix on Edit Hook](development/ai/ruff-fix-hook.md) - PostToolUse hook that runs ruff --fix on edited Python files
@@ -122,7 +127,6 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Template Tools Reference](template/tools-reference.md) - Complete reference for all template tools in tools/pyproject_template/
 - [Tooling Roles and Architectural Boundaries](development/tooling-roles.md) - What each tool is for, who uses it, and where runtime code ends and dev tooling begins
 - [Usage Guide](usage/basics.md) - Package usage and development workflows
-- [Using Generated Clients with Auto-Detection](GENERATED_CLIENT_USAGE.md)
 - [Using This Template](template/index.md) - Overview of using pyproject-template for your Python projects
 <!-- END:all -->
 

--- a/docs/deployment/publishing.md
+++ b/docs/deployment/publishing.md
@@ -1,3 +1,14 @@
+---
+title: Publishing to PyPI
+description: Release-time procedure for publishing the package to PyPI
+audience:
+  - contributors
+tags:
+  - release
+  - pypi
+  - deployment
+---
+
 # Publishing to PyPI
 
 ## One-Time Setup

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,3 +1,15 @@
+---
+title: Architecture
+description: How the OPNsense OpenAPI generator parses and emits clients
+audience:
+  - contributors
+tags:
+  - architecture
+  - internals
+  - parser
+  - generator
+---
+
 # Architecture Documentation
 
 ## Overview

--- a/docs/development/heuristics.md
+++ b/docs/development/heuristics.md
@@ -1,3 +1,14 @@
+---
+title: Heuristic Schema Generation
+description: How the generator infers response schemas when none are declared
+audience:
+  - contributors
+tags:
+  - heuristics
+  - internals
+  - generator
+---
+
 # Heuristic Schema Generation Guide
 
 ## Quick Reference
@@ -669,6 +680,6 @@ Track coverage improvements over time:
 
 ## Further Reading
 
-- [Full Architecture Documentation](./ARCHITECTURE.md)
+- [Full Architecture Documentation](./architecture.md)
 - [OPNsense MVC Documentation](https://docs.opnsense.org/development/backend.html)
 - [OpenAPI Specification](https://swagger.io/specification/)

--- a/docs/usage/generated-client.md
+++ b/docs/usage/generated-client.md
@@ -1,3 +1,14 @@
+---
+title: Generated Client Usage
+description: Use generated OPNsense clients with automatic version detection
+audience:
+  - users
+tags:
+  - usage
+  - client
+  - auto-detection
+---
+
 # Using Generated Clients with Auto-Detection
 
 This document shows how to use the generated OpenAPI clients with automatic version detection.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,18 +63,16 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Project:
-      - Architecture: ARCHITECTURE.md
-      - Generated Client Usage: GENERATED_CLIENT_USAGE.md
-      - Heuristics: HEURISTICS.md
-      - Publishing: PUBLISHING.md
   - Getting Started:
       - Installation: getting-started/installation.md
   - Usage:
       - Basics: usage/basics.md
       - CLI Guide: usage/cli.md
+      - Generated Client: usage/generated-client.md
   - Development:
       - Coding Standards: development/coding-standards.md
+      - Architecture: development/architecture.md
+      - Heuristics: development/heuristics.md
       - CI/CD & Testing: development/ci-cd-testing.md
       - GitHub Repository Settings: development/github-repository-settings.md
       - Doit Tasks Reference: development/doit-tasks-reference.md
@@ -92,6 +90,7 @@ nav:
   - Deployment:
       - Development: deployment/development.md
       - Production: deployment/production.md
+      - Publishing: deployment/publishing.md
   - Template:
       - Overview: template/index.md
       - Template Manager: template/manage.md


### PR DESCRIPTION
## Description

PR #13 (the bulk template sync that resolved issue #12) preserved a `Project`
catch-all section in `mkdocs.yml` containing four legacy top-level docs
(`ARCHITECTURE.md`, `HEURISTICS.md`, `GENERATED_CLIENT_USAGE.md`,
`PUBLISHING.md`). Issue #16 flagged that this section diverged from the
upstream `pyproject-template` conventions:

- No upstream equivalent — upstream distributes its docs into topic groups
  (Development, Usage, Deployment) and never carries a `Project` catch-all.
- PascalCase / `SNAKE_CASE.md` filenames in a kebab-case repo.
- Missing the YAML frontmatter (`title`, `description`, `audience`, `tags`)
  that every sibling doc carries.

Per the implementation plan recorded on issue #16, this PR dissolves the
`Project` section, redistributes the four docs into upstream-style groups
under their kebab-case names, and adds the standard frontmatter.

## Related Issue

Addresses #16

## Type of Change

- [x] Documentation update

## Changes Made

**File moves (via `git mv`, history preserved — use `git log --follow`):**

- `docs/ARCHITECTURE.md` → `docs/development/architecture.md`
- `docs/HEURISTICS.md` → `docs/development/heuristics.md`
- `docs/GENERATED_CLIENT_USAGE.md` → `docs/usage/generated-client.md`
- `docs/PUBLISHING.md` → `docs/deployment/publishing.md`

Each moved file gained YAML frontmatter (`title` / `description` / `audience`
/ `tags`) consistent with sibling docs in its new section.

**Nav reorganization (`mkdocs.yml`):**

- Removed the 5-line `Project` catch-all section.
- Appended `Generated Client` to the Usage section.
- Inserted `Architecture` and `Heuristics` after `Coding Standards` in the
  Development section.
- Appended `Publishing` after `Production` in the Deployment section.

**Inbound-reference fixes:**

- `README.md` line 87 — link updated from
  `[GENERATED_CLIENT_USAGE.md](docs/GENERATED_CLIENT_USAGE.md)` to
  `[Generated Client Usage](docs/usage/generated-client.md)`.
- `docs/development/heuristics.md` line 672 — internal cross-link to the
  architecture doc rewritten in relative form (`./architecture.md`) now that
  both files live in the same directory.

**Pre-commit regeneration:**

- `docs/TABLE_OF_CONTENTS.md` regenerated by the pre-commit hook to reflect
  the new layout.

A repository-wide `git grep` for `ARCHITECTURE.md`, `HEURISTICS.md`,
`GENERATED_CLIENT_USAGE.md`, and `PUBLISHING.md` (excluding the
auto-generated `docs/TABLE_OF_CONTENTS.md` and `CHANGELOG.md`) returned
zero matches, confirming no stale inbound references remain.

## Testing

- [x] All existing tests pass (`uv run doit check`)
- [x] `uv run doit docs_build` succeeds — no new mkdocs warnings introduced
      (pre-existing decision-log link warnings are unchanged)
- [x] Manually verified the regenerated `mkdocs.yml` renders the four docs
      under their new groups

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — docs-only nav reorganization)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (changelog is generated by commitizen at release)
- [x] My changes generate no new warnings

## Additional Notes

### Closing the PR #13 follow-up trio

Issue #16 was the third of three follow-ups carved out of PR #13 (template
sync, addressed issue #12). With this merge the trio is fully resolved:

| # | Issue | PR | Topic |
| - | ----- | -- | ----- |
| Parent | #12 | #13 | Template sync to `pyproject-template@0cdab3e` |
| Follow-up 1 | #15 | #17 | `core.py` / `logging.py` + benchmarks scaffolding |
| Follow-up 2 | #14 | #18 | docs/examples drift, skip upstream `.py` examples |
| Follow-up 3 (this PR) | #16 | _this PR_ | Dissolve `Project` nav section |

### Remaining open thread (not part of the trio)

Future `python tools/pyproject_template/manage.py check` runs will continue
to flag the upstream files this project deliberately skips (e.g.,
upstream-only example scripts) until a per-file exclusion mechanism exists
in `manage.py`. This was first noted in PR #17 and PR #18; it is _not_ a
follow-up of the template-sync trio and should be tracked as its own issue
when convenient.
