### PR TITLE
chore: complete .envrc and .envrc.local.example sync

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,43 @@
-# Load local environment variables (not committed)
+# direnv configuration for this project
+# This file contains project defaults and is version-controlled
+# For personal overrides, create .envrc.local (git-ignored)
+
+# Activate virtual environment (if it exists)
+# Run 'uv sync --all-extras --dev' to create the virtual environment
+if [ -d .venv ]; then
+  source .venv/bin/activate
+else
+  echo "⚠️  Virtual environment not found. Run: uv sync --all-extras --dev"
+fi
+
+# Cache directories (all point to tmp/)
+export UV_CACHE_DIR=${UV_CACHE_DIR:-"$(pwd)/tmp/.uv_cache"}
+export RUFF_CACHE_DIR=${RUFF_CACHE_DIR:-"$(pwd)/tmp/.ruff_cache"}
+export MYPY_CACHE_DIR=${MYPY_CACHE_DIR:-"$(pwd)/tmp/.mypy_cache"}
+export COVERAGE_FILE=${COVERAGE_FILE:-"$(pwd)/tmp/.coverage"}
+export PRE_COMMIT_HOME=${PRE_COMMIT_HOME:-"$(pwd)/tmp/.pre-commit"}
+
+# Add local bin to PATH
+export PATH="$PWD/.venv/bin:$PATH"
+
+# Project-specific environment variables
+# Uncomment and customize as needed:
+# export DEBUG=${DEBUG:-false}
+# export LOG_LEVEL=${LOG_LEVEL:-INFO}
+
+# Load user-specific settings from .envrc.local (git-ignored)
+# This is where you put personal overrides and credentials
 if [ -f .envrc.local ]; then
-    source .envrc.local
+  source_env .envrc.local
+fi
+watch_file .envrc.local
+
+# Show loaded configuration
+echo "🔧 Project environment loaded"
+echo "   Python: $(python --version 2>&1)"
+echo "   Caches: tmp/ (UV, Ruff, Mypy, Coverage, Pre-commit)"
+
+# Helpful warnings
+if [ ! -f .envrc.local ]; then
+  echo "💡 Tip: Create .envrc.local for personal settings (API keys, debug flags, etc.)"
 fi

--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -1,7 +1,30 @@
-# Copy this file to .envrc.local and fill in your credentials
-# .envrc.local is gitignored and will not be committed
+# .envrc.local - Personal settings (git-ignored)
+# Copy this file to .envrc.local and customize
 
-# OPNsense API credentials
+# OPNsense API credentials (NEVER commit these!)
 export OPNSENSE_URL="https://your-opnsense-host"
 export OPNSENSE_API_KEY="your-api-key"
 export OPNSENSE_API_SECRET="your-api-secret"
+
+# Development preferences
+# export DEBUG=true
+# export LOG_LEVEL=DEBUG
+
+# Override cache locations if needed (defaults set in .envrc point to tmp/)
+# export UV_CACHE_DIR="$(pwd)/tmp/.uv_cache"
+# export RUFF_CACHE_DIR="$(pwd)/tmp/.ruff_cache"
+# export MYPY_CACHE_DIR="$(pwd)/tmp/.mypy_cache"
+# export COVERAGE_FILE="$(pwd)/tmp/.coverage"
+# export PRE_COMMIT_HOME="$(pwd)/tmp/.pre-commit"
+
+# Custom environment variables for your workflow
+# export EDITOR=vim
+# export BROWSER=firefox
+
+# Claude Code LSP support (enables fast code navigation)
+# Uncomment to enable Language Server Protocol in Claude Code
+# See .claude/lsp-setup.md for setup instructions
+# export ENABLE_LSP_TOOL=1
+
+# Pyright LSP debug logging (uncomment for troubleshooting LSP issues)
+# export PYRIGHT_PYTHON_DEBUG=1


### PR DESCRIPTION
## Description

Completes the `.envrc` and `.envrc.local.example` sync that PR #13's plan listed but the implementation skipped. PR #13 section 4 explicitly called these out ("Sync `.envrc`, `.envrc.local.example` (preserve local tweaks)") but neither file was touched in that PR. The gap was discovered while preparing the v0.3.0 release.

## Related Issue

Addresses #21

## Type of Change

- [x] Documentation update (developer environment configuration)

## Changes Made

**`.envrc` — adopted upstream verbatim.** The project's previous file was a 4-line stub that only sourced `.envrc.local`. Upstream's 43-line version is pure infrastructure (no project-specific content to preserve):

- Auto-activates `.venv` if present (with a "run `uv sync --all-extras --dev`" hint when missing).
- Redirects dev tool caches into `tmp/`: `UV_CACHE_DIR`, `RUFF_CACHE_DIR`, `MYPY_CACHE_DIR`, `COVERAGE_FILE`, `PRE_COMMIT_HOME`.
- Uses `source_env` + `watch_file .envrc.local` so direnv reloads on edit.
- Prints load diagnostics + a tip to create `.envrc.local` if missing.

**`.envrc.local.example` — merged.** Preserved the OPNsense API credentials block (the project-specific reason this file exists at all) and appended upstream's generic examples:

- `DEBUG` / `LOG_LEVEL` toggle examples (especially useful with the centralized logging adopted in PR #17).
- Cache directory overrides (mirror of the vars `.envrc` sets).
- `EDITOR` / `BROWSER` workflow vars.
- `ENABLE_LSP_TOOL=1` for Claude Code LSP support — pairs with `.claude/lsp-setup.md` adopted by PR #13.
- `PYRIGHT_PYTHON_DEBUG=1` for LSP troubleshooting.

Dropped upstream's generic `API_KEY` / `DATABASE_URL` placeholder examples since the OPNsense credentials block already serves the concrete-credentials role for this project. Added "(NEVER commit these!)" annotation to the OPNsense block to carry forward the safety reminder from upstream's generic version.

## Testing

- [x] `uv run doit check` passes (format, lint, type, security, spell, test).
- [x] `diff .envrc tmp/extracted/pyproject-template-main/.envrc` returns clean — file matches upstream verbatim.
- [ ] No new tests required (developer environment config files; no Python code).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — config files only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (this PR *is* the docs/config update)
- [ ] I have updated the CHANGELOG.md (handled by commitizen at release time)
- [x] My changes generate no new warnings

## Additional Notes

This is a small follow-up that was caught while preparing the v0.3.0 release. Lands the missing devenv config so the release ships with the correct `.envrc` setup.

The per-file exclusion mechanism follow-up (issue #20 here, upstream `pyproject-template#481`) is the only other open thread from the PR #13 sync arc. Neither blocks the upcoming release.
