### PR TITLE
chore: add structural lint for spec path routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,27 @@ jobs:
       - name: Run dependency audit
         run: uv run pip-audit --skip-editable
 
+      - name: Resolve latest committed spec version
+        id: latest-spec
+        if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          version=$(uv run python -c "from opnsense_openapi import list_available_specs; print(list_available_specs()[-1])")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Latest committed spec: $version"
+
+      - name: Cache OPNsense source archive
+        if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'
+        uses: actions/cache@v5
+        with:
+          path: tmp/opnsense_source
+          key: opnsense-source-${{ steps.latest-spec.outputs.version }}
+
+      - name: Download OPNsense source for spec path routing lint
+        if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'
+        run: |
+          uv run python -c "from opnsense_openapi.downloader import SourceDownloader; SourceDownloader().download('${{ steps.latest-spec.outputs.version }}')"
+
       - name: Run tests with coverage
         run: uv run pytest --cov=opnsense_openapi --cov-report=xml:tmp/coverage.xml --cov-report=term -v
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -636,6 +636,14 @@ print(f"Coverage: {with_schema}/{total} ({with_schema/total*100:.1f}%)")
 EOF
 ```
 
+### Spec Path Routing Lint
+
+A structural lint in `tests/test_spec_path_routing.py` verifies that every
+`/api/{module}/{controller}/{action}` path in the latest committed spec
+reverse-maps to a real `*Controller.php` file in the matching OPNsense
+source archive. See [Spec Path Routing Lint](ci-cd-testing.md#spec-path-routing-lint)
+in the CI/CD Testing Guide for details.
+
 ## Performance
 
 ### Benchmarks

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -786,6 +786,61 @@ The `gh-benchmarks` branch can optionally serve a trend chart via GitHub Pages:
 
 This step is optional and not required for the core tracking functionality.
 
+## Spec Path Routing Lint
+
+### What It Checks
+
+The structural lint in `tests/test_spec_path_routing.py` verifies that every
+`/api/{module}/{controller}/{action}` path in the latest committed OpenAPI
+spec resolves to a real `*Controller.php` file in the matching OPNsense
+source archive. It exists to catch regressions of issue #32, where the
+generator emitted collapsed-lowercase URL segments (e.g.,
+`/api/interfaces/vlansettings`) that did not reverse-map to any real
+controller (`OPNsense/Interfaces/Api/VlanSettingsController.php`).
+
+The lint walks the latest spec returned by `opnsense_openapi.list_available_specs()`,
+parses each path, applies `to_class_name(controller_segment) + "Controller.php"`,
+and asserts the resulting file exists. Module directory resolution is
+case-insensitive to mirror OPNsense's `Mvc/Router.php` namespace fallback
+(so `/api/dhcrelay` resolves to `OPNsense/DHCRelay`, etc.). All failures
+are collected and reported in a single assertion so a single test run
+surfaces every broken path.
+
+### The `requires_opnsense_source` Marker
+
+The lint test is decorated with `@pytest.mark.requires_opnsense_source`.
+When the OPNsense source archive cannot be materialized (e.g., no network
+in a developer sandbox), the test skips with a clear reason instead of
+hard-failing. CI pre-downloads the archive in a dedicated workflow step
+and caches it keyed on the spec version, so the lint runs unconditionally
+in CI and stays fast across reruns.
+
+### Running Locally
+
+```bash
+uv run pytest tests/test_spec_path_routing.py -v
+```
+
+The test downloads the OPNsense source via `SourceDownloader` if the
+archive is not already cached at `tmp/opnsense_source/{version}/`. To
+pre-populate the cache without running the test:
+
+```bash
+uv run python -c "from opnsense_openapi.downloader import SourceDownloader; SourceDownloader().download('26.1.6')"
+```
+
+The unmarked unit tests in the same file exercise the path-checking helper
+against synthetic fake-tree fixtures (no network required) and run on
+every CI pass.
+
+### Live-API Contract Test (Out of Scope)
+
+A live-API contract test (`@pytest.mark.live_opnsense`) that exercises
+spec endpoints against a real OPNsense instance is tracked as a separate
+follow-up issue and is **not** implemented here. The structural lint
+described above ships first because it provides PR-time signal without
+requiring a live target.
+
 ## Troubleshooting
 
 ### Coverage Below Threshold

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,7 @@ python_functions = ["test_*"]
 markers = [
     "benchmark: marks tests as performance benchmarks (deselect with '--benchmark-disable')",
     "property: marks tests as property-based tests (run with Hypothesis)",
+    "requires_opnsense_source: lint requires a downloaded OPNsense source archive (skipped if missing)",
 ]
 
 [tool.pytest-benchmark]

--- a/tests/test_spec_path_routing.py
+++ b/tests/test_spec_path_routing.py
@@ -86,6 +86,11 @@ def check_spec_paths(spec: dict[str, Any], controllers_root: Path) -> list[tuple
     """
     failures: list[tuple[str, str]] = []
     paths: dict[str, Any] = spec.get("paths", {})
+    # Cache the on-disk filename set for each Api directory we look into.
+    # Compared as Python strings (case-sensitive) regardless of the host
+    # filesystem's case sensitivity — Path.is_file() would silently succeed
+    # for casing-mismatched lookups on macOS (APFS) and Windows (NTFS).
+    api_listings: dict[Path, set[str]] = {}
 
     for path in paths:
         match = PATH_PATTERN.match(path)
@@ -107,15 +112,21 @@ def check_spec_paths(spec: dict[str, Any], controllers_root: Path) -> list[tuple
             )
             continue
 
+        api_dir = module_dir / "Api"
+        if api_dir not in api_listings:
+            api_listings[api_dir] = (
+                {entry.name for entry in api_dir.iterdir() if entry.is_file()}
+                if api_dir.is_dir()
+                else set()
+            )
+
         expected_filename = f"{to_class_name(controller)}Controller.php"
-        expected_file = module_dir / "Api" / expected_filename
-        if not expected_file.is_file():
+        if expected_filename not in api_listings[api_dir]:
             failures.append(
                 (
                     path,
-                    f"controller file not found: expected {expected_file} "
-                    f"(controller segment {controller!r} -> "
-                    f"{to_class_name(controller)}Controller.php)",
+                    f"controller file not found: expected {api_dir / expected_filename} "
+                    f"(controller segment {controller!r} -> {expected_filename})",
                 )
             )
 

--- a/tests/test_spec_path_routing.py
+++ b/tests/test_spec_path_routing.py
@@ -1,0 +1,290 @@
+"""Structural lint for spec path routing.
+
+This test suite verifies that every ``/api/{module}/{controller}/{action}``
+path in a committed OpenAPI spec resolves to a real ``*Controller.php`` file
+in the matching OPNsense source archive. It is the structural lint counterpart
+to issue #32, which shipped 56 specs whose paths did not reverse-map to real
+controllers because the generator was emitting collapsed-lowercase URL
+segments instead of snake_case.
+
+Two layers of tests live here:
+
+* The marked lint test (``requires_opnsense_source``) loads the latest
+  committed spec via :func:`opnsense_openapi.list_available_specs` and walks
+  every path. It downloads the source archive on demand via
+  :class:`opnsense_openapi.downloader.SourceDownloader` and skips with a
+  clear reason when the download cannot proceed (e.g., no network).
+* Unmarked unit tests exercise the path-checking helper against a synthetic
+  fake source tree under ``tmp_path``. These run on every CI pass and
+  demonstrate that the lint catches the #32 regression class plus the
+  case-insensitive module fallback that mirrors OPNsense's
+  ``Mvc/Router.php:78-89``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from opnsense_openapi import get_spec_path, list_available_specs
+from opnsense_openapi.downloader import SourceDownloader
+from opnsense_openapi.utils import to_class_name
+
+PATH_PATTERN = re.compile(r"^/api/([^/]+)/([^/]+)/([^/]+)(?:/.*)?$")
+
+
+def _resolve_module_dir(controllers_root: Path, module: str) -> Path | None:
+    """Resolve a URL module segment to its on-disk directory.
+
+    OPNsense's ``Mvc/Router.php`` (lines 78-89) falls back to a
+    case-insensitive lookup when the literal module name does not match a
+    namespace directory. This mirrors that behavior so e.g. ``/api/dhcrelay``
+    resolves to ``OPNsense/DHCRelay`` and ``/api/openvpn`` resolves to
+    ``OPNsense/OpenVPN``.
+
+    Args:
+        controllers_root: Path to the ``OPNsense/`` directory containing
+            module subdirectories.
+        module: The module segment from a URL path (e.g., ``"dhcrelay"``).
+
+    Returns:
+        The resolved module directory, or ``None`` if no case-insensitive
+        match exists.
+    """
+    direct = controllers_root / module
+    if direct.is_dir():
+        return direct
+
+    module_lower = module.lower()
+    for entry in controllers_root.iterdir():
+        if entry.is_dir() and entry.name.lower() == module_lower:
+            return entry
+    return None
+
+
+def check_spec_paths(spec: dict[str, Any], controllers_root: Path) -> list[tuple[str, str]]:
+    """Validate that every spec path resolves to a real controller file.
+
+    For each path of the form ``/api/{module}/{controller}/{action}[/...]``,
+    asserts that ``{controllers_root}/{module}/Api/{Controller}Controller.php``
+    exists, where ``{Controller}`` is :func:`to_class_name` applied to the
+    URL controller segment. Module resolution is case-insensitive to match
+    ``Mvc/Router.php``'s namespace fallback.
+
+    Args:
+        spec: A loaded OpenAPI spec dict (must contain a ``paths`` key).
+        controllers_root: Path to the ``OPNsense/`` directory inside a
+            downloaded source archive.
+
+    Returns:
+        A list of ``(path, reason)`` tuples for every path that does not
+        resolve. An empty list means every path resolved successfully.
+    """
+    failures: list[tuple[str, str]] = []
+    paths: dict[str, Any] = spec.get("paths", {})
+
+    for path in paths:
+        match = PATH_PATTERN.match(path)
+        if not match:
+            # Defensive: skip paths that don't match the 4+-segment shape.
+            # A well-formed spec shouldn't contain these, but we don't want
+            # to crash the lint over a malformed entry.
+            continue
+
+        module, controller, _ = match.groups()
+        module_dir = _resolve_module_dir(controllers_root, module)
+        if module_dir is None:
+            failures.append(
+                (
+                    path,
+                    f"module directory not found: no case-insensitive match for "
+                    f"{module!r} under {controllers_root}",
+                )
+            )
+            continue
+
+        expected_filename = f"{to_class_name(controller)}Controller.php"
+        expected_file = module_dir / "Api" / expected_filename
+        if not expected_file.is_file():
+            failures.append(
+                (
+                    path,
+                    f"controller file not found: expected {expected_file} "
+                    f"(controller segment {controller!r} -> "
+                    f"{to_class_name(controller)}Controller.php)",
+                )
+            )
+
+    return failures
+
+
+def _make_fake_controller_tree(root: Path, controllers: dict[str, list[str]]) -> Path:
+    """Create a synthetic ``OPNsense/<Module>/Api/<File>Controller.php`` tree.
+
+    Args:
+        root: Directory under which the ``OPNsense/`` tree is materialized.
+        controllers: Mapping of module name (e.g., ``"Interfaces"``) to a
+            list of controller filenames (e.g., ``["VlanSettingsController.php"]``).
+
+    Returns:
+        Path to the created ``OPNsense/`` directory (suitable to pass as
+        ``controllers_root`` to :func:`check_spec_paths`).
+    """
+    opnsense_root = root / "OPNsense"
+    for module, files in controllers.items():
+        api_dir = opnsense_root / module / "Api"
+        api_dir.mkdir(parents=True, exist_ok=True)
+        for filename in files:
+            (api_dir / filename).write_text("<?php // synthetic test fixture\n", encoding="utf-8")
+    return opnsense_root
+
+
+@pytest.mark.requires_opnsense_source
+def test_latest_spec_paths_resolve_to_real_controllers() -> None:
+    """Every path in the latest committed spec resolves to a real controller.
+
+    This test downloads the OPNsense source archive matching the latest
+    committed spec via :class:`SourceDownloader`. If the download fails
+    (e.g., no network in a developer sandbox), the test skips with a clear
+    reason. CI pre-downloads the archive in a separate workflow step so the
+    test runs unconditionally there.
+    """
+    available = list_available_specs()
+    if not available:
+        pytest.skip("No committed specs available")
+
+    # list_available_specs() returns a list sorted by version key, so the
+    # last entry is the highest version.
+    latest_version = available[-1]
+    spec_path = get_spec_path(latest_version)
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+
+    downloader = SourceDownloader()
+    try:
+        controllers_root = downloader.download(latest_version)
+    except (RuntimeError, OSError) as exc:
+        pytest.skip(
+            f"Unable to materialize OPNsense source for {latest_version}: {exc}. "
+            "Run `uv run python -c 'from opnsense_openapi.downloader import "
+            f"SourceDownloader; SourceDownloader().download({latest_version!r})'` "
+            "to populate the cache."
+        )
+
+    failures = check_spec_paths(spec, controllers_root)
+
+    rendered = "\n".join(f"  {path}: {reason}" for path, reason in failures)
+    assert not failures, (
+        f"{len(failures)} path(s) in opnsense-{latest_version}.json do not "
+        f"resolve to real OPNsense controllers under {controllers_root}:\n"
+        f"{rendered}"
+    )
+
+
+def test_check_spec_paths_catches_collapsed_lowercase_controller(
+    tmp_path: Path,
+) -> None:
+    """Lint catches the #32 regression class (collapsed-lowercase controller).
+
+    This proves the lint would have rejected the broken spec emitted before
+    PR #36: a path of ``/api/interfaces/vlansettings/...`` does not map to
+    ``OPNsense/Interfaces/Api/VlanSettingsController.php`` under the
+    snake_case-aware :func:`to_class_name` rule. ``vlansettings`` collapses
+    to ``Vlansettings``, which is not the real controller filename.
+    """
+    controllers_root = _make_fake_controller_tree(
+        tmp_path,
+        {"Interfaces": ["VlanSettingsController.php"]},
+    )
+
+    broken_spec = {"paths": {"/api/interfaces/vlansettings/searchItem": {}}}
+    failures = check_spec_paths(broken_spec, controllers_root)
+    assert len(failures) == 1
+    assert failures[0][0] == "/api/interfaces/vlansettings/searchItem"
+    assert "VlansettingsController.php" in failures[0][1]
+
+    # Conversely, the correctly snake_cased path resolves cleanly.
+    correct_spec = {"paths": {"/api/interfaces/vlan_settings/searchItem": {}}}
+    assert check_spec_paths(correct_spec, controllers_root) == []
+
+
+def test_check_spec_paths_module_resolution_is_case_insensitive(
+    tmp_path: Path,
+) -> None:
+    """Lint mirrors Mvc/Router.php's case-insensitive module fallback.
+
+    URLs use lowercase module segments (``/api/dhcrelay``, ``/api/openvpn``)
+    but the on-disk module directories are mixed-case (``DHCRelay``,
+    ``OpenVPN``). The lint must not flag these as missing controllers.
+    """
+    controllers_root = _make_fake_controller_tree(
+        tmp_path,
+        {
+            "DHCRelay": ["SettingsController.php"],
+            "OpenVPN": ["InstancesController.php"],
+        },
+    )
+
+    spec = {
+        "paths": {
+            "/api/dhcrelay/settings/get": {},
+            "/api/openvpn/instances/search": {},
+        }
+    }
+    assert check_spec_paths(spec, controllers_root) == []
+
+
+def test_check_spec_paths_reports_missing_module(tmp_path: Path) -> None:
+    """Lint reports a clear failure when the module directory is absent."""
+    controllers_root = _make_fake_controller_tree(
+        tmp_path,
+        {"Interfaces": ["SettingsController.php"]},
+    )
+
+    spec = {"paths": {"/api/nonexistent/foo/bar": {}}}
+    failures = check_spec_paths(spec, controllers_root)
+    assert len(failures) == 1
+    assert "module directory not found" in failures[0][1]
+
+
+def test_check_spec_paths_skips_non_api_paths(tmp_path: Path) -> None:
+    """Paths that don't match the 4+-segment ``/api/...`` shape are skipped.
+
+    The lint is defensive: a well-formed spec shouldn't contain these, but
+    we don't want to crash if one slips in.
+    """
+    controllers_root = _make_fake_controller_tree(tmp_path, {})
+
+    spec = {
+        "paths": {
+            "/health": {},
+            "/api/onlytwo": {},
+            "/api/three/segments": {},
+        }
+    }
+    assert check_spec_paths(spec, controllers_root) == []
+
+
+def test_check_spec_paths_collects_all_failures(tmp_path: Path) -> None:
+    """Lint collects every failing path, not just the first one."""
+    controllers_root = _make_fake_controller_tree(
+        tmp_path,
+        {"Interfaces": ["SettingsController.php"]},
+    )
+
+    spec = {
+        "paths": {
+            "/api/interfaces/settings/get": {},  # ok
+            "/api/interfaces/missing/get": {},  # bad controller
+            "/api/nonexistent/foo/bar": {},  # bad module
+        }
+    }
+    failures = check_spec_paths(spec, controllers_root)
+    failed_paths = {path for path, _ in failures}
+    assert failed_paths == {
+        "/api/interfaces/missing/get",
+        "/api/nonexistent/foo/bar",
+    }


### PR DESCRIPTION
## Description

Adds the structural lint layer that was identified as missing after #32
shipped: every `/api/{module}/{controller}/{action}` path in the latest
committed spec must reverse-map to a real `*Controller.php` file in the
matching OPNsense source archive. This is the test that would have caught
the collapsed-lowercase URL-segment regression at PR time. The
complementary live-API contract test
(`@pytest.mark.live_opnsense`) is intentionally split to a separate
follow-up issue and is not part of this PR.

## Related Issue

Addresses #35

## Type of Change

- [x] Test improvement

## Changes Made

- `tests/test_spec_path_routing.py` (new) — structural lint with 6 tests:
  - 1 e2e test, marked `@pytest.mark.requires_opnsense_source`, that
    walks every path in the latest committed spec
    (`opnsense_openapi.list_available_specs()[-1]`), downloads the
    matching OPNsense source archive via `SourceDownloader` if it isn't
    cached, and asserts each path resolves to a real
    `OPNsense/<Module>/Api/<Controller>Controller.php` file. Module
    resolution mirrors `Mvc/Router.php`'s case-insensitive namespace
    fallback (so `/api/dhcrelay` -> `OPNsense/DHCRelay`,
    `/api/openvpn` -> `OPNsense/OpenVPN`).
  - 5 unit tests over a synthetic fake-tree fixture: catches the #32
    regression class (collapsed-lowercase controller segment),
    case-insensitive module resolution, missing-module reporting,
    malformed-path skip behavior, and multi-failure collection.
- `pyproject.toml` — registers the `requires_opnsense_source` pytest
  marker so the e2e test does not warn-on-import.
- `.github/workflows/ci.yml` — three new steps, gated to
  `ubuntu-latest` plus the newest Python matrix cell only: resolve the
  latest spec version via `list_available_specs()`, cache
  `tmp/opnsense_source` keyed on that version, and pre-download the
  archive via `SourceDownloader` so the e2e test runs (not skips) in
  CI. Other matrix cells skip the lint, keeping CI cost flat.
- `docs/development/ci-cd-testing.md` — new "Spec Path Routing Lint"
  section: what it checks, the marker, how to run locally, and a note
  that the live-API contract test is a separate follow-up.
- `docs/development/architecture.md` — one-line cross-reference under
  the "Testing" section pointing to the new lint.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes
- [x] `doit check` passes locally

The 5 unit tests run on every CI pass and need no network. The e2e test
downloads the OPNsense source via `SourceDownloader` if not cached;
locally it skips with a clear reason when the download cannot proceed,
and in CI the new pre-download step ensures it never skips. Reviewers
can re-run the suite with:

```bash
uv run pytest tests/test_spec_path_routing.py -v
```

**Validation against the bug class it catches:** an earlier run of this
lint, before #37 (PR #38) regenerated the committed specs, correctly
flagged ~120 broken paths in the not-yet-regenerated `26.1.6` spec —
concrete evidence that the lint catches the regression class it is
designed to catch. After #37 merged with the regenerated specs, the
branch was rebased on `main`, the work-in-progress popped cleanly, and
the lint now passes against every path in the latest spec.

## Follow-up

A separate issue will be filed for the live-API contract test
(`@pytest.mark.live_opnsense`) that exercises spec endpoints against a
real OPNsense instance. That work needs a live-target fixture and CI
secret-handling story that is out of scope here.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (auto-generated at release time)
- [x] My changes generate no new warnings
