### PR TITLE
refactor: stabilize generated-client module path; add floor spec matching

### DIFF
--- a/docs/decisions/0001-spec-matching-floor-over-highest-module-path-keyed-by-resolved-spec-version.md
+++ b/docs/decisions/0001-spec-matching-floor-over-highest-module-path-keyed-by-resolved-spec-version.md
@@ -1,0 +1,72 @@
+# ADR-0001: Spec matching: floor over highest, module path keyed by resolved spec version
+
+## Status
+
+Accepted
+
+## Decision
+
+`find_best_matching_spec(version)` defaults to **floor** matching: when no
+exact spec is committed, return the highest spec at or below the
+requested version, not the highest spec sharing `major.minor`. The
+generated-client module directory is keyed off the *resolved* spec
+version, not the raw user-supplied version, so security-patch revisions
+of the same release (`26.1.6`, `26.1.6_2`, ...) share a single generated
+client.
+
+The legacy "highest" behavior remains available via
+`find_best_matching_spec(version, mode="highest")` for callers that
+want it.
+
+## Rationale
+
+Two failure modes in InfraFoundry's direct-API spike against a `26.1.6_2`
+box drove this decision:
+
+1. **Wrong-direction matching.** With `[25.7.4, 25.7.6, 25.7.7]`
+   committed and the box reporting `25.7.5`, the resolver returned
+   `25.7.7`. Endpoints introduced between `25.7.5` and `25.7.7` then
+   appeared in the generated client and surfaced as 404s at runtime.
+   Floor matching biases the client toward a subset that is guaranteed
+   to exist on the box.
+
+2. **Module-path churn across security patches.** The auto-generator
+   keyed its output directory off `version.replace(".", "_")`, so each
+   security-patch boot (`26.1.6_1`, `26.1.6_2`, ...) wrote a fresh
+   `generated/v26_1_6_N/` even though the resolver mapped them all to
+   `opnsense-26.1.6.json`. Codegen ran on every boot. Keying the module
+   directory off the resolved spec version (which strips the `_N`
+   suffix) collapses these to a single `generated/v26_1_6/` and the
+   second boot is a no-op.
+
+The default flip is a deliberate breaking change: callers requesting a
+non-exact version receive a different spec than before. The PR
+description and changelog flag it explicitly.
+
+## Consequences
+
+- **Breaking change.** `find_best_matching_spec("25.7.5")` against
+  `[25.7.4, 25.7.6, 25.7.7]` now returns `25.7.4`, not `25.7.7`. Callers
+  that need the old behavior must opt in with `mode="highest"`.
+- **Stable generated-client paths.** A `26.1.6_2` box and a `26.1.6_3`
+  box share a single `generated/v26_1_6/` directory. Old per-revision
+  directories (`v26_1_6_2/`) are not auto-deleted; they sit unused.
+- **Floor failure raises.** If no committed spec is at or below the
+  requested version, `find_best_matching_spec` raises `FileNotFoundError`
+  rather than silently returning a spec above the box. CLI surfaces
+  surface this with a clear message.
+
+## Related Issues
+
+- Issue #34 — refactor: stabilize generated-client module path across
+  patch revisions; add closest-floor spec matching
+
+## Related Documentation
+
+- [Spec Version Resolution](../development/spec-version-resolution.md) —
+  end-user explanation of the matching rule and the `_N` suffix policy.
+- `src/opnsense_openapi/specs.py` — `find_best_matching_spec`,
+  `_version_key`, `version_from_spec_path`.
+- `src/opnsense_openapi/client/base.py` — `_resolved_module_dir`,
+  `_auto_generate_client`, `OPNsenseClient.api`.
+

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -101,5 +101,4 @@ The Issue contains the full discussion; the ADR summarizes the outcome.
 
 | ADR | Title | Status |
 |-----|-------|--------|
-
-_(No project-level ADRs yet.)_
+| [0001](0001-spec-matching-floor-over-highest-module-path-keyed-by-resolved-spec-version.md) | Spec matching: floor over highest, module path keyed by resolved spec version | Accepted |

--- a/docs/development/spec-version-resolution.md
+++ b/docs/development/spec-version-resolution.md
@@ -1,0 +1,91 @@
+---
+title: Spec Version Resolution
+description: How a live OPNsense version maps to a committed OpenAPI spec
+audience:
+  - contributors
+  - integrators
+tags:
+  - specs
+  - versioning
+  - architecture
+---
+
+# Spec Version Resolution
+
+## Overview
+
+When an `OPNsenseClient` connects to a live box, the box reports a version
+string (for example `25.7.5` or `26.1.6_2`). That version is rarely the
+version of an OpenAPI spec we have committed in
+`src/opnsense_openapi/specs/`. The resolver in
+[`opnsense_openapi.specs`](../reference/api.md) maps the reported version
+to a spec file and a generated-client module directory using two rules.
+
+## Rule 1: Security-patch suffixes are normalized
+
+OPNsense releases security patches by appending `_1`, `_2`, ... to the
+underlying release (`26.1.6_2` is a security patch of `26.1.6`). The
+**OpenAPI surface does not change between security patches** of the same
+release — controllers, parameters, and responses are identical. The
+resolver therefore treats `26.1.6_2` as equivalent to `26.1.6` for spec
+selection and generated-client identity.
+
+In code this is implemented by `_version_key()` stripping a trailing `_N`
+from the last component before parsing:
+
+```python
+_version_key("26.1.6")     == (26, 1, 6)
+_version_key("26.1.6_2")   == (26, 1, 6)
+```
+
+A direct consequence: the generated-client directory is keyed off the
+*resolved* spec version, not the raw input. The first time the client
+auto-generates for a `26.1.6_2` box, codegen lands in
+`src/opnsense_openapi/generated/v26_1_6/`. A subsequent boot reporting
+`26.1.6_3` finds the existing `v26_1_6/` directory and skips codegen.
+
+## Rule 2: Floor matching is the default
+
+When no exact spec exists for the requested version, the resolver collects
+all specs sharing the requested `major.minor` and picks one based on the
+`mode` argument to `find_best_matching_spec`:
+
+- **`"floor"` (default)** — the highest committed spec **at or below** the
+  requested version. This is the conservative choice: it never claims an
+  endpoint exists on a box that may not have shipped it yet.
+- **`"highest"`** — the highest committed spec sharing `major.minor`. This
+  is the legacy behavior, retained for callers that want to bias toward
+  newer surfaces (interactive docs browsing where false positives are
+  acceptable, for instance).
+
+Concrete example: a box reports `25.7.5`. Committed specs are
+`[25.7.4, 25.7.6, 25.7.7]`. The resolver picks:
+
+| Mode | Result | Rationale |
+|------|--------|-----------|
+| `floor` (default) | `25.7.4` | Highest spec at or below the box's version. |
+| `highest` | `25.7.7` | Highest spec sharing `25.7`, ignoring the box's actual version. |
+
+If no spec is at or below the requested version under floor mode, the
+resolver raises `FileNotFoundError` rather than silently picking a spec
+above the box.
+
+## Why these defaults
+
+In direct-API integrations (the use case that drives this project), an
+endpoint that exists in the spec but not on the box returns 404 at
+runtime. That failure mode is more painful than the inverse — a missing
+endpoint that the box happens to support — because users hit it during
+normal operation, not during exploration. Floor matching biases the
+client toward the conservative subset that is guaranteed to exist on the
+box.
+
+## Related
+
+- [ADR-0001: Spec matching: floor over highest, module path keyed by resolved spec version](../decisions/0001-spec-matching-floor-over-highest-module-path-keyed-by-resolved-spec-version.md) (Accepted)
+- Issue #34 — the bug report and discussion that drove this rule.
+- `src/opnsense_openapi/specs.py` — `find_best_matching_spec`,
+  `_version_key`, `version_from_spec_path`.
+- `src/opnsense_openapi/client/base.py` — `_resolved_module_dir`, the
+  helper that ties the generated-client path to the resolved spec
+  version.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
   - Development:
       - Coding Standards: development/coding-standards.md
       - Architecture: development/architecture.md
+      - Spec Version Resolution: development/spec-version-resolution.md
       - Heuristics: development/heuristics.md
       - CI/CD & Testing: development/ci-cd-testing.md
       - GitHub Repository Settings: development/github-repository-settings.md
@@ -101,6 +102,7 @@ nav:
       - Tools Reference: template/tools-reference.md
   - Decisions:
       - Overview: decisions/README.md
+      - ADR-0001 Spec matching: decisions/0001-spec-matching-floor-over-highest-module-path-keyed-by-resolved-spec-version.md
       - ADR-9001 uv: decisions/9001-use-uv-for-package-management.md
       - ADR-9002 doit: decisions/9002-use-doit-for-task-automation.md
       - ADR-9003 ruff: decisions/9003-use-ruff-for-linting-and-formatting.md

--- a/src/opnsense_openapi/client/base.py
+++ b/src/opnsense_openapi/client/base.py
@@ -14,7 +14,7 @@ from urllib.parse import urljoin
 import httpx
 
 from opnsense_openapi.openapi import APIWrapper, SuggestedParameters
-from opnsense_openapi.specs import find_best_matching_spec
+from opnsense_openapi.specs import find_best_matching_spec, version_from_spec_path
 
 logger = logging.getLogger(__name__)
 
@@ -27,25 +27,57 @@ class APIResponseError(Exception):
         self.response_text = response_text
 
 
+def _resolved_module_dir(version: str) -> tuple[Path, str, Path]:
+    """Resolve the spec for ``version`` and return its canonical client paths.
+
+    Both ``_auto_generate_client`` and the :pyattr:`OPNsenseClient.api`
+    property need the *same* derivation: resolve the spec, then key the
+    generated-client directory off the spec's version (not the raw user
+    input). Centralizing here keeps them in lock-step and ensures that a
+    raw input like ``26.1.6_2`` lands in ``generated/v26_1_6/`` whenever the
+    resolver maps it to ``opnsense-26.1.6.json``.
+
+    Args:
+        version: Raw OPNsense version string (may include a ``_N`` suffix).
+
+    Returns:
+        Tuple of ``(spec_path, resolved_version, client_dir)`` where
+        ``resolved_version`` is the version segment of ``spec_path`` (e.g.
+        ``"26.1.6"``) and ``client_dir`` is
+        ``src/opnsense_openapi/generated/v{resolved_with_underscores}/``.
+
+    Raises:
+        FileNotFoundError: If no spec can be resolved for ``version`` (the
+            error originates in :func:`find_best_matching_spec`).
+    """
+    spec_path: Path = find_best_matching_spec(version)
+    resolved_version: str = version_from_spec_path(spec_path)
+    version_module: str = resolved_version.replace(".", "_")
+    client_dir: Path = Path(__file__).parent.parent / "generated" / f"v{version_module}"
+    return spec_path, resolved_version, client_dir
+
+
 def _auto_generate_client(version: str) -> bool:
     """Automatically generate Python client if spec exists but client doesn't.
 
+    The generated-client directory is keyed off the *resolved* spec version,
+    not the raw input. This means ``26.1.6_2`` and ``26.1.6_3`` both land in
+    ``generated/v26_1_6/`` whenever the resolver maps them to
+    ``opnsense-26.1.6.json``, and the second invocation finds an existing
+    client without re-running codegen.
+
     Args:
-        version: OPNsense version string (e.g., '24.7.1')
+        version: OPNsense version string (e.g., '24.7.1' or '26.1.6_2')
 
     Returns:
         True if client was generated or already exists, False if spec doesn't exist
     """
-    # Check if spec file exists
+    # Check if spec file exists and derive the canonical client dir.
     try:
-        spec_path = find_best_matching_spec(version)
+        spec_path, _, client_dir = _resolved_module_dir(version)
     except FileNotFoundError:
         logger.debug(f"No spec file found for version {version}")
         return False
-
-    # Check if generated client already exists
-    version_module = version.replace(".", "_")
-    client_dir = Path(__file__).parent.parent / "generated" / f"v{version_module}"
 
     if client_dir.exists():
         logger.debug(f"Generated client already exists at {client_dir}")
@@ -402,8 +434,23 @@ class OPNsenseClient:
                 f"  opnsense-openapi generate {version}"
             )
 
-        # Import the generated client for this version
-        version_module: str = version.replace(".", "_")
+        # Resolve again to derive the canonical module path. ``_auto_generate_client``
+        # already used this derivation; call it once more here so the importlib
+        # path matches the directory ``_auto_generate_client`` populated.
+        try:
+            _, resolved_version, _ = _resolved_module_dir(version)
+        except FileNotFoundError as e:
+            # Should be unreachable: ``_auto_generate_client`` already returned True.
+            raise RuntimeError(
+                f"No OpenAPI spec found for version {version}. "
+                f"Generate it with:\n"
+                f"  opnsense-openapi download {version}\n"
+                f"  opnsense-openapi generate {version}"
+            ) from e
+
+        # Import the generated client for the *resolved* version, so that
+        # ``26.1.6`` and ``26.1.6_2`` share a single generated client.
+        version_module: str = resolved_version.replace(".", "_")
         module_path: str = f"opnsense_openapi.generated.v{version_module}.opnsense_openapi_client"
 
         try:
@@ -417,8 +464,10 @@ class OPNsenseClient:
             api_client: Any = generated.Client(base_url=f"{self.base_url}/api")
             api_client.set_httpx_client(self._client)
 
-            # Wrap in GeneratedAPI for version-agnostic access
-            return GeneratedAPI(api_client, version)
+            # Wrap in GeneratedAPI for version-agnostic access. Pass the
+            # resolved version so ``GeneratedAPI`` builds importlib paths
+            # against the directory ``_auto_generate_client`` populated.
+            return GeneratedAPI(api_client, resolved_version)
 
         except ImportError as e:
             # This should rarely happen now that we auto-generate, but keep as fallback

--- a/src/opnsense_openapi/specs.py
+++ b/src/opnsense_openapi/specs.py
@@ -1,7 +1,26 @@
-"""Utilities for managing OPNsense API specification files."""
+"""Utilities for managing OPNsense API specification files.
+
+This module owns spec discovery and version-to-spec resolution. The matching
+strategy is documented in
+[`docs/development/spec-version-resolution.md`](../../docs/development/spec-version-resolution.md)
+and codified in ADR-0001.
+
+Two rules drive the resolver:
+
+1. **`_N` security-patch suffixes are equivalent to the underlying release.**
+   The OpenAPI surface does not change between security patches, so
+   ``26.1.6_2`` resolves to the same spec as ``26.1.6``.
+2. **"Floor" matching is the default.** When no exact spec is committed,
+   ``find_best_matching_spec`` returns the highest spec **at or below** the
+   requested version. The previous "highest" behavior is still available via
+   ``mode="highest"`` for callers that explicitly want it.
+"""
 
 import re
 from pathlib import Path
+from typing import Literal
+
+_SPEC_FILENAME_RE = re.compile(r"^opnsense-(?P<version>.+)\.json$")
 
 
 def get_specs_dir() -> Path:
@@ -24,9 +43,9 @@ def list_available_specs() -> list[str]:
 
     for spec_file in specs_dir.glob("opnsense-*.json"):
         # Extract version from filename: opnsense-24.7.1.json -> 24.7.1
-        match = re.match(r"opnsense-(.+)\.json$", spec_file.name)
+        match = _SPEC_FILENAME_RE.match(spec_file.name)
         if match:
-            versions.append(match.group(1))
+            versions.append(match.group("version"))
 
     return sorted(versions, key=_version_key)
 
@@ -55,35 +74,51 @@ def get_spec_path(version: str) -> Path:
     return spec_file
 
 
-def find_best_matching_spec(version: str) -> Path:
+def find_best_matching_spec(version: str, mode: Literal["highest", "floor"] = "floor") -> Path:
     """Find the best matching spec for a given version.
 
-    If exact match exists, returns it. Otherwise, finds the closest version
-    by matching major.minor and taking the highest patch version.
+    If an exact match exists, returns it. Otherwise the resolver collects all
+    specs sharing the requested ``major.minor`` and picks one based on
+    ``mode``:
+
+    - ``"floor"`` (default): the highest committed spec **at or below** the
+      requested version. This is correct when the OPNsense box is between two
+      committed specs — picking a higher spec would expose endpoints that may
+      not exist on the box.
+    - ``"highest"``: the highest committed spec sharing ``major.minor``. This
+      is the legacy behavior, retained for callers that want to bias toward
+      newer surfaces (e.g. interactive docs browsing).
+
+    Security-patch suffixes (``26.1.6_2``) are normalized to their underlying
+    release (``26.1.6``) for comparison, since the OpenAPI surface does not
+    change between security patches of the same release.
 
     Args:
-        version: OPNsense version string (e.g., '24.7.1')
+        version: OPNsense version string (e.g., '24.7.1' or '26.1.6_2')
+        mode: Selection strategy. Default ``"floor"``.
 
     Returns:
-        Path to the best matching spec file
+        Path to the best matching spec file.
 
     Raises:
-        FileNotFoundError: If no suitable spec can be found
+        FileNotFoundError: If no suitable spec can be found. In ``"floor"``
+            mode this includes the case where no committed spec is at or
+            below the requested version.
     """
-    # Try exact match first
+    # Try exact match first (cheap short-circuit, independent of mode).
     try:
         return get_spec_path(version)
     except FileNotFoundError:
         pass
 
-    # Parse version components
+    # Parse version components.
     version_parts = version.split(".")
     if len(version_parts) < 2:
         raise FileNotFoundError(f"Invalid version format: {version}")
 
     major_minor = f"{version_parts[0]}.{version_parts[1]}"
 
-    # Find all specs matching major.minor
+    # Find all specs matching major.minor.
     available = list_available_specs()
     matching = [v for v in available if v.startswith(f"{major_minor}.") or v == major_minor]
 
@@ -93,19 +128,69 @@ def find_best_matching_spec(version: str) -> Path:
             f"Available versions: {', '.join(available)}"
         )
 
-    # Return the highest matching version
-    best_match = sorted(matching, key=_version_key)[-1]
+    requested_key = _version_key(version)
+
+    if mode == "floor":
+        # Filter to specs at or below the requested version, then take highest.
+        candidates = [v for v in matching if _version_key(v) <= requested_key]
+        if not candidates:
+            raise FileNotFoundError(
+                f"No spec at or below version {version} (mode='floor'). "
+                f"Available {major_minor}.x versions: {', '.join(matching)}"
+            )
+        best_match = sorted(candidates, key=_version_key)[-1]
+    else:
+        # mode == "highest": legacy behavior — take highest among major.minor.
+        best_match = sorted(matching, key=_version_key)[-1]
+
     return get_spec_path(best_match)
+
+
+def version_from_spec_path(path: Path) -> str:
+    """Extract the version string from an ``opnsense-{version}.json`` path.
+
+    This is the inverse of :func:`get_spec_path`. The client auto-generator
+    uses it to derive a stable module directory from the *resolved* spec
+    rather than the raw user-provided version, so that distinct
+    security-patch revisions of the same release share a single generated
+    client.
+
+    Args:
+        path: Path whose filename matches ``opnsense-{version}.json``.
+
+    Returns:
+        The version segment (e.g., ``"26.1.6"``).
+
+    Raises:
+        ValueError: If the filename does not match the expected shape.
+    """
+    match = _SPEC_FILENAME_RE.match(path.name)
+    if not match:
+        raise ValueError(f"Path {path} does not match expected 'opnsense-{{version}}.json' shape")
+    return match.group("version")
 
 
 def _version_key(version: str) -> tuple[int, ...]:
     """Convert version string to sortable tuple.
 
+    Trailing ``_N`` security-patch suffixes on the **last** component are
+    stripped before parsing, so ``26.1.6`` and ``26.1.6_2`` produce the same
+    key. Security patches are equivalent to the underlying release for spec
+    selection because the OpenAPI surface does not change between them.
+
     Args:
-        version: Version string like '24.7.1'
+        version: Version string like ``"24.7.1"`` or ``"26.1.6_2"``.
 
     Returns:
-        Tuple of integers for sorting (24, 7, 1)
+        Tuple of integers for sorting (e.g., ``(24, 7, 1)`` or ``(26, 1, 6)``).
     """
     parts = version.split(".")
+    if not parts:
+        return ()
+    # Strip a trailing _N suffix from the last component only. The OPNsense
+    # surface does not differ between security patches.
+    last = parts[-1]
+    underscore_idx = last.find("_")
+    if underscore_idx != -1:
+        parts[-1] = last[:underscore_idx]
     return tuple(int(p) for p in parts)

--- a/tests/test_client_auto_generate.py
+++ b/tests/test_client_auto_generate.py
@@ -10,10 +10,10 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-from opnsense_openapi.client.base import _auto_generate_client
+from opnsense_openapi.client.base import _auto_generate_client, _resolved_module_dir
 
 
-def test_auto_generate_returns_false_when_spec_missing(tmp_path: Path) -> None:
+def test_auto_generate_returns_false_when_spec_missing() -> None:
     """_auto_generate_client returns False if no spec file matches the version."""
     with patch(
         "opnsense_openapi.client.base.find_best_matching_spec",
@@ -95,3 +95,71 @@ def test_auto_generate_returns_false_on_generator_failure(tmp_path: Path) -> Non
         ),
     ):
         assert _auto_generate_client("24.7") is False
+
+
+# --- Module-path stability across security-patch revisions ----------------
+
+
+def test_resolved_module_dir_strips_security_patch_suffix(tmp_path: Path) -> None:
+    """``26.1.6`` and ``26.1.6_2`` resolve to the same generated-client directory.
+
+    This is the core invariant for issue #34: distinct security-patch revisions
+    of the same release must share a single generated client, since the
+    OpenAPI surface does not change between them.
+    """
+    spec_path = tmp_path / "opnsense-26.1.6.json"
+    spec_path.write_text("{}")
+
+    with patch(
+        "opnsense_openapi.client.base.find_best_matching_spec",
+        return_value=spec_path,
+    ):
+        _, resolved_a, dir_a = _resolved_module_dir("26.1.6")
+        _, resolved_b, dir_b = _resolved_module_dir("26.1.6_2")
+
+    assert resolved_a == resolved_b == "26.1.6"
+    assert dir_a == dir_b
+    assert dir_a.name == "v26_1_6"
+
+
+def test_auto_generate_skips_codegen_for_security_patch_revision(tmp_path: Path) -> None:
+    """A second invocation with a ``_N`` suffix finds the existing client.
+
+    Sequence:
+        1. First call (raw version ``26.1.6``) — no client yet, codegen runs.
+        2. Second call (raw version ``26.1.6_2``, same resolver target) —
+           the canonical ``v26_1_6`` directory now exists, so codegen is
+           **not** invoked again.
+    """
+    spec_path = tmp_path / "opnsense-26.1.6.json"
+    spec_path.write_text("{}")
+
+    # Track which client_dir paths the auto-generator considered "existing".
+    existed: set[str] = set()
+
+    def fake_exists(self: Path) -> bool:
+        return str(self) in existed
+
+    def fake_check_call(cmd: list[str], **_: object) -> int:
+        # Record that this run "created" the client_dir, so the next
+        # client_dir.exists() returns True.
+        idx = cmd.index("--output-path")
+        existed.add(cmd[idx + 1])
+        return 0
+
+    with (
+        patch(
+            "opnsense_openapi.client.base.find_best_matching_spec",
+            return_value=spec_path,
+        ),
+        patch("pathlib.Path.exists", new=fake_exists),
+        patch("shutil.which", return_value="/usr/bin/openapi-python-client"),
+        patch("subprocess.check_call", side_effect=fake_check_call) as check_call,
+    ):
+        # First call: no v26_1_6 dir yet → codegen runs.
+        assert _auto_generate_client("26.1.6") is True
+        # Second call with security-patch suffix: short-circuits.
+        assert _auto_generate_client("26.1.6_2") is True
+
+    # codegen invoked exactly once across both calls.
+    assert check_call.call_count == 1

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -1,8 +1,14 @@
 """Tests for spec loading functions."""
 
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from opnsense_openapi import find_best_matching_spec, get_spec_path, list_available_specs
+from opnsense_openapi.specs import _version_key, version_from_spec_path
 
 
 def test_list_available_specs() -> None:
@@ -40,15 +46,132 @@ def test_find_best_matching_spec_exact() -> None:
 
 
 def test_find_best_matching_spec_fallback() -> None:
-    """Test finding best match with non-existent patch version."""
-    # Should find the highest 24.7.x
+    """A request above the highest committed patch falls back to that patch.
+
+    Under floor matching, ``24.7.999`` is greater than every committed
+    ``24.7.x``, so the highest existing patch is the correct floor.
+    """
     path = find_best_matching_spec("24.7.999")
     assert path.name.startswith("opnsense-24.7.")
     assert path.exists()
 
 
 def test_find_best_matching_spec_no_match() -> None:
-    """Test finding best match with no suitable version."""
+    """Test finding best match with no suitable major.minor."""
     with pytest.raises(FileNotFoundError) as exc_info:
         find_best_matching_spec("99.99.99")
     assert "No spec found" in str(exc_info.value)
+
+
+# --- _version_key ---------------------------------------------------------
+
+
+def test_version_key_basic_three_part() -> None:
+    """Three-part versions parse to a 3-tuple."""
+    assert _version_key("26.1.6") == (26, 1, 6)
+
+
+def test_version_key_strips_security_patch_suffix() -> None:
+    """A trailing ``_N`` suffix on the last component is stripped, not added."""
+    assert _version_key("26.1.6_2") == (26, 1, 6)
+    assert _version_key("26.1.6") == _version_key("26.1.6_2")
+
+
+def test_version_key_numeric_not_lexical() -> None:
+    """Comparison is numeric: 26.1.10 > 26.1.6_2 (lexical would say <)."""
+    assert _version_key("26.1.10") > _version_key("26.1.6_2")
+
+
+def test_version_key_two_segment() -> None:
+    """Two-segment versions like ``24.7`` round-trip cleanly."""
+    assert _version_key("24.7") == (24, 7)
+
+
+# --- version_from_spec_path ----------------------------------------------
+
+
+def test_version_from_spec_path_round_trips() -> None:
+    """``opnsense-26.1.6.json`` -> ``"26.1.6"``."""
+    assert version_from_spec_path(Path("specs/opnsense-26.1.6.json")) == "26.1.6"
+
+
+def test_version_from_spec_path_rejects_unknown_shape() -> None:
+    """A path that does not match the expected filename raises ``ValueError``."""
+    with pytest.raises(ValueError, match="does not match"):
+        version_from_spec_path(Path("nonsense.txt"))
+
+
+# --- find_best_matching_spec: mode and security-patch handling -----------
+
+
+def _patched_specs_dir(tmp_path: Path, versions: list[str]) -> None:
+    """Helper: write empty JSON files for each version under ``tmp_path``."""
+    for v in versions:
+        (tmp_path / f"opnsense-{v}.json").write_text("{}")
+
+
+def test_find_best_matching_spec_default_is_floor(tmp_path: Path) -> None:
+    """Calling without ``mode`` behaves identically to ``mode='floor'``."""
+    _patched_specs_dir(tmp_path, ["25.7.4", "25.7.6", "25.7.7"])
+
+    with patch("opnsense_openapi.specs.get_specs_dir", return_value=tmp_path):
+        default = find_best_matching_spec("25.7.5")
+        floor = find_best_matching_spec("25.7.5", mode="floor")
+        assert default == floor
+        assert default.name == "opnsense-25.7.4.json"
+
+
+def test_find_best_matching_spec_floor_with_security_patch(tmp_path: Path) -> None:
+    """``26.1.6_2`` resolves to the ``26.1.6`` spec under floor matching."""
+    _patched_specs_dir(
+        tmp_path,
+        ["26.1.1", "26.1.2", "26.1.3", "26.1.4", "26.1.5", "26.1.6"],
+    )
+
+    with patch("opnsense_openapi.specs.get_specs_dir", return_value=tmp_path):
+        path = find_best_matching_spec("26.1.6_2")
+        assert path.name == "opnsense-26.1.6.json"
+
+
+def test_find_best_matching_spec_floor_picks_below_not_above(tmp_path: Path) -> None:
+    """``25.7.5`` against ``[25.7.4, 25.7.6, 25.7.7]`` picks ``25.7.4``."""
+    _patched_specs_dir(tmp_path, ["25.7.4", "25.7.6", "25.7.7"])
+
+    with patch("opnsense_openapi.specs.get_specs_dir", return_value=tmp_path):
+        path = find_best_matching_spec("25.7.5", mode="floor")
+        assert path.name == "opnsense-25.7.4.json"
+
+
+def test_find_best_matching_spec_highest_preserves_legacy(tmp_path: Path) -> None:
+    """``mode='highest'`` returns the highest matching ``major.minor.x``."""
+    _patched_specs_dir(tmp_path, ["25.7.4", "25.7.6", "25.7.7"])
+
+    with patch("opnsense_openapi.specs.get_specs_dir", return_value=tmp_path):
+        path = find_best_matching_spec("25.7.5", mode="highest")
+        assert path.name == "opnsense-25.7.7.json"
+
+
+def test_find_best_matching_spec_floor_raises_when_below_all(tmp_path: Path) -> None:
+    """Floor mode raises when no committed spec is at or below the request."""
+    _patched_specs_dir(tmp_path, ["24.7.5", "24.7.6"])
+
+    with (
+        patch("opnsense_openapi.specs.get_specs_dir", return_value=tmp_path),
+        pytest.raises(FileNotFoundError) as exc_info,
+    ):
+        find_best_matching_spec("24.7.1", mode="floor")
+
+    msg = str(exc_info.value)
+    assert "at or below" in msg
+    assert "24.7.1" in msg
+    assert "24.7.5" in msg
+
+
+def test_find_best_matching_spec_exact_short_circuits_in_both_modes(tmp_path: Path) -> None:
+    """An exact-match request returns the exact spec regardless of ``mode``."""
+    _patched_specs_dir(tmp_path, ["25.7.4", "25.7.5", "25.7.7"])
+
+    with patch("opnsense_openapi.specs.get_specs_dir", return_value=tmp_path):
+        floor = find_best_matching_spec("25.7.5", mode="floor")
+        highest = find_best_matching_spec("25.7.5", mode="highest")
+        assert floor.name == highest.name == "opnsense-25.7.5.json"


### PR DESCRIPTION
## Description

Refactors spec resolution and generated-client path derivation to fix two
runtime failures observed against a `26.1.6_2` box during InfraFoundry's
direct-API spike (sibling work to #40):

1. **Wrong-direction matching.** `find_best_matching_spec("25.7.5")`
   against committed `[25.7.4, 25.7.6, 25.7.7]` previously returned
   `25.7.7`. Endpoints introduced after `25.7.5` then surfaced in the
   generated client and 404'd at runtime. The default selection mode now
   picks the highest committed spec **at or below** the requested
   version (floor matching).
2. **Module-path churn across security patches.** The auto-generator
   keyed its output directory off `version.replace(".", "_")`, so each
   security-patch boot (`26.1.6_1`, `26.1.6_2`, ...) wrote a fresh
   `generated/v26_1_6_N/` even though the resolver mapped them all to
   `opnsense-26.1.6.json`. Codegen ran on every boot. The generated
   directory is now keyed off the *resolved* spec version, collapsing
   these to a single `generated/v26_1_6/`.

## Related Issue

Addresses #34

## Type of Change

- [x] Breaking change (default `mode` flip on `find_best_matching_spec`)
- [x] Code refactoring
- [x] Documentation update

## Breaking Changes

`find_best_matching_spec(version)` now defaults to `mode="floor"`.
Callers that relied on the previous "highest matching `major.minor.x`"
behavior must opt in explicitly:

```python
find_best_matching_spec("25.7.5", mode="highest")
```

Concrete change in resolved spec for the same input:

| Input | Committed specs | Old result | New result (floor) |
|-------|-----------------|------------|--------------------|
| `25.7.5` | `[25.7.4, 25.7.6, 25.7.7]` | `25.7.7` | `25.7.4` |
| `26.1.6_2` | `[..., 26.1.6]` | `26.1.6` (matched by major.minor) | `26.1.6` (matched by floor + `_N` strip) |

Floor matching also raises `FileNotFoundError` when no committed spec is
at or below the request, instead of silently picking one above it.
Rationale: an endpoint that exists in the spec but not on the live box
returns 404 at runtime, which is more painful than the inverse.

## Changes Made

### `_N` suffix-stripping rule

`_version_key` now strips a trailing `_N` from the last component before
parsing. `_version_key("26.1.6") == _version_key("26.1.6_2") == (26, 1, 6)`.
The OPNsense OpenAPI surface does not change between security patches
of the same release, so they're equivalent for spec selection.

### Floor as the default matching mode

`find_best_matching_spec(version, mode: Literal["highest", "floor"] = "floor")`.
Default flipped to `"floor"`. `"highest"` retained for callers that want
to bias toward newer surfaces (e.g. interactive docs browsing).

### Module-path stabilization across patch revisions

New helpers:

- `version_from_spec_path(path)` in `specs.py` — public inverse of
  `get_spec_path`. Extracts the version segment from an
  `opnsense-{version}.json` path.
- `_resolved_module_dir(version)` in `client/base.py` — single
  derivation used by both `_auto_generate_client` and the `api`
  property. Resolves the spec, then keys the generated-client
  directory off the *resolved* spec version.

Worked example: a `26.1.6_2` box now lands in
`src/opnsense_openapi/generated/v26_1_6/`. A subsequent boot reporting
`26.1.6_3` finds the existing directory and skips codegen. Old
per-revision directories (`v26_1_6_2/`) are not auto-deleted; they sit
unused.

### `api` property change (deviation from plan)

The `api` property change is slightly larger than the plan called for:
`GeneratedAPI` also receives the resolved version, otherwise its inner
`importlib.import_module` calls would target the raw-version path and
miss the canonical directory `_auto_generate_client` populated.

### CLI audit — no code changes needed

All four `find_best_matching_spec` call sites in
`src/opnsense_openapi/cli.py` work correctly under the new floor
default with no code change:

| Site | Command | Reasoning |
|------|---------|-----------|
| L241 | `validate` | Floor is correct — don't validate against phantom endpoints. |
| L371 | `build-client` | Floor is the conservative choice. |
| L654 | `serve-docs` | Floor prevents documenting endpoints the box does not expose. |
| L675 | `serve-docs` no-version fallback | `available[-1]` always exact-matches, so `mode` is irrelevant. |

### ADR + docs

- `docs/decisions/0001-spec-matching-floor-over-highest-module-path-keyed-by-resolved-spec-version.md`
  — new ADR (Status: Accepted), created via `doit adr`. Cites the new
  docs page and links Issue #34.
- `docs/development/spec-version-resolution.md` — new contributor/integrator
  page describing both rules with a worked example.
- `docs/decisions/README.md` — adds ADR-0001 to the project-level index.
- `mkdocs.yml` — wires up the ADR + docs page.

## Testing

- [x] All existing tests pass (`uv run doit check` — full check suite green)
- [x] Added new tests for new functionality

New / updated coverage:

- `tests/test_specs.py`
  - `_version_key` basic three-part parsing, `_N` suffix-stripping,
    numeric-not-lexical comparison, two-segment versions.
  - `version_from_spec_path` round-trip and unknown-shape rejection.
  - `find_best_matching_spec` default-is-floor, floor with security
    patch, floor picks-below-not-above, `mode="highest"` legacy
    preservation, floor raises when below all, exact-match
    short-circuits in both modes.
- `tests/test_client_auto_generate.py`
  - `_resolved_module_dir` strips security-patch suffix — `26.1.6` and
    `26.1.6_2` resolve to the same directory `v26_1_6/`.
  - `_auto_generate_client` skips codegen on the second invocation with
    a `_N` suffix — `subprocess.check_call` invoked exactly once across
    both calls.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

Sibling to #40 — both issues surfaced from the same `26.1.6_2`
direct-API spike. #40 covered the live contract test for path routing;
this PR covers the spec-resolution and module-path layer underneath.
