### PR TITLE
fix: distinguish codegen failure modes in OPNsenseClient.api

### DIFF
--- a/src/opnsense_openapi/cli.py
+++ b/src/opnsense_openapi/cli.py
@@ -341,7 +341,7 @@ def build_client(
         typer.secho(
             "Error: 'openapi-python-client' not found in PATH.", fg=typer.colors.RED, err=True
         )
-        typer.echo("Install it with: uv pip install openapi-python-client")
+        typer.echo("Install it with: uv tool install openapi-python-client")
         raise typer.Exit(code=1)
 
     # Determine version
@@ -475,7 +475,7 @@ def setup(
         typer.secho(
             "Error: 'openapi-python-client' not found in PATH.", fg=typer.colors.RED, err=True
         )
-        typer.echo("Install it with: uv pip install openapi-python-client")
+        typer.echo("Install it with: uv tool install openapi-python-client")
         raise typer.Exit(code=1)
 
     # Step 1: Download source

--- a/src/opnsense_openapi/client/base.py
+++ b/src/opnsense_openapi/client/base.py
@@ -14,7 +14,11 @@ from urllib.parse import urljoin
 import httpx
 
 from opnsense_openapi.openapi import APIWrapper, SuggestedParameters
-from opnsense_openapi.specs import find_best_matching_spec, version_from_spec_path
+from opnsense_openapi.specs import (
+    find_best_matching_spec,
+    list_available_specs,
+    version_from_spec_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +61,7 @@ def _resolved_module_dir(version: str) -> tuple[Path, str, Path]:
     return spec_path, resolved_version, client_dir
 
 
-def _auto_generate_client(version: str) -> bool:
+def _auto_generate_client(version: str) -> str:
     """Automatically generate Python client if spec exists but client doesn't.
 
     The generated-client directory is keyed off the *resolved* spec version,
@@ -70,25 +74,48 @@ def _auto_generate_client(version: str) -> bool:
         version: OPNsense version string (e.g., '24.7.1' or '26.1.6_2')
 
     Returns:
-        True if client was generated or already exists, False if spec doesn't exist
+        The resolved spec version (e.g. ``"26.1.6"`` for an input of
+        ``"26.1.6_2"``). Callers can use this to derive the canonical
+        generated-client module path without re-resolving the spec.
+
+    Raises:
+        RuntimeError: With a cause-tagged message identifying which of three
+            distinct failure modes occurred:
+
+            - **Spec missing** — no committed spec resolves for ``version``.
+              The message lists currently available versions and suggests
+              ``opnsense-openapi generate {version}``.
+            - **CLI missing** — ``openapi-python-client`` is not on
+              ``PATH``. The message includes the resolved spec path and the
+              correct install command (``uv tool install
+              openapi-python-client``).
+            - **Codegen failed** — ``openapi-python-client`` ran but exited
+              non-zero. The message includes the version, spec path, return
+              code, and captured stderr.
     """
     # Check if spec file exists and derive the canonical client dir.
     try:
-        spec_path, _, client_dir = _resolved_module_dir(version)
-    except FileNotFoundError:
-        logger.debug(f"No spec file found for version {version}")
-        return False
+        spec_path, resolved_version, client_dir = _resolved_module_dir(version)
+    except FileNotFoundError as exc:
+        available = list_available_specs()
+        available_str = ", ".join(available) if available else "<none>"
+        raise RuntimeError(
+            f"No OpenAPI spec for version {version}; available=[{available_str}]. "
+            f"Generate with: opnsense-openapi generate {version}"
+        ) from exc
 
     if client_dir.exists():
         logger.debug(f"Generated client already exists at {client_dir}")
-        return True
+        return resolved_version
 
     # Check if openapi-python-client is available
     if not shutil.which("openapi-python-client"):
-        logger.warning(
-            "openapi-python-client not found. Install it with: uv pip install openapi-python-client"
+        raise RuntimeError(
+            f"openapi-python-client is not on PATH; cannot generate the typed "
+            f"client for version {version} (spec found at {spec_path}). "
+            f"Install with `uv tool install openapi-python-client` and retry, "
+            f"or run `opnsense-openapi generate {version}` manually."
         )
-        return False
 
     # Generate the client
     logger.info(f"Auto-generating Python client for version {version}...")
@@ -121,12 +148,25 @@ def _auto_generate_client(version: str) -> bool:
             config_path,
         ]
 
-        subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
-        logger.info(f"✓ Successfully generated client for version {version}")
-        return True
-    except subprocess.CalledProcessError as e:
-        logger.error(f"Failed to generate client: {e}")
-        return False
+        try:
+            subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError as exc:
+            stderr_bytes = exc.stderr if isinstance(exc.stderr, bytes | bytearray) else b""
+            stderr_text = (
+                stderr_bytes.decode("utf-8", errors="replace").strip()
+                if stderr_bytes
+                else "<empty>"
+            )
+            raise RuntimeError(
+                f"openapi-python-client failed for version {version} "
+                f"(spec={spec_path}, returncode={exc.returncode}). "
+                f"Re-run interactively for full output: "
+                f"opnsense-openapi generate {version}. "
+                f"Captured stderr: {stderr_text}"
+            ) from exc
+
+        logger.info(f"Successfully generated client for version {version}")
+        return resolved_version
     finally:
         # Clean up temp config file
         with contextlib.suppress(Exception):
@@ -401,7 +441,10 @@ class OPNsenseClient:
             GeneratedAPI wrapper for version-agnostic access
 
         Raises:
-            RuntimeError: If no version is available or no generated client exists
+            RuntimeError: If no version is available, the spec is missing,
+                ``openapi-python-client`` is not on ``PATH``, or codegen
+                failed. The message identifies which of those occurred (see
+                :func:`_auto_generate_client`).
 
         Example (No version-specific imports needed!):
             >>> client = OPNsenseClient(..., auto_detect_version=True)
@@ -424,29 +467,12 @@ class OPNsenseClient:
                 "or enable auto_detect_version."
             )
 
-        # Try to auto-generate the client if it doesn't exist
-        if not _auto_generate_client(version):
-            # Spec doesn't exist - provide instructions to generate it
-            raise RuntimeError(
-                f"No OpenAPI spec found for version {version}. "
-                f"Generate it with:\n"
-                f"  opnsense-openapi download {version}\n"
-                f"  opnsense-openapi generate {version}"
-            )
-
-        # Resolve again to derive the canonical module path. ``_auto_generate_client``
-        # already used this derivation; call it once more here so the importlib
-        # path matches the directory ``_auto_generate_client`` populated.
-        try:
-            _, resolved_version, _ = _resolved_module_dir(version)
-        except FileNotFoundError as e:
-            # Should be unreachable: ``_auto_generate_client`` already returned True.
-            raise RuntimeError(
-                f"No OpenAPI spec found for version {version}. "
-                f"Generate it with:\n"
-                f"  opnsense-openapi download {version}\n"
-                f"  opnsense-openapi generate {version}"
-            ) from e
+        # Auto-generate (or confirm) the typed client. The helper raises
+        # ``RuntimeError`` with a cause-tagged message on any failure mode
+        # (spec missing, CLI missing, codegen failed) and returns the
+        # *resolved* spec version on success — which is what we need below
+        # to build the importlib path.
+        resolved_version: str = _auto_generate_client(version)
 
         # Import the generated client for the *resolved* version, so that
         # ``26.1.6`` and ``26.1.6_2`` share a single generated client.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,7 @@
 """Tests for OPNsense API client."""
 
+from pathlib import Path
+
 import pytest
 
 from opnsense_openapi.client import OPNsenseClient
@@ -139,46 +141,48 @@ def test_api_response_error() -> None:
 
 
 def test_auto_generate_client_spec_missing() -> None:
-    """Test auto-generation when spec doesn't exist."""
+    """Test auto-generation raises a spec-missing RuntimeError when no spec exists."""
     from opnsense_openapi.client.base import _auto_generate_client
 
-    result = _auto_generate_client("99.99.99")
-    assert result is False
+    with pytest.raises(RuntimeError) as exc_info:
+        _auto_generate_client("99.99.99")
+
+    msg = str(exc_info.value)
+    assert "No OpenAPI spec for version 99.99.99" in msg
+    assert "opnsense-openapi generate 99.99.99" in msg
 
 
 def test_auto_generate_client_spec_exists() -> None:
-    """Test auto-generation when spec exists."""
+    """Test auto-generation when a spec exists.
+
+    Returns the *resolved* spec version (a string) when codegen succeeds or the
+    generated client already exists; raises a CLI-missing RuntimeError when the
+    spec is present but ``openapi-python-client`` is not on PATH.
+    """
     import shutil
-    from pathlib import Path
 
     from opnsense_openapi.client.base import _auto_generate_client
 
-    # This should return True because the spec exists (24.7.1)
-    # If the client already exists, it returns True
-    # If it needs to generate and openapi-python-client is available, it returns True
-    # If openapi-python-client is not available, it returns False
-    result = _auto_generate_client("24.7.1")
-
-    # Check if the generated client exists OR if openapi-python-client is not available
+    # Check whether the generated client dir already exists or the tool is on PATH.
     version_module = "24_7_1"
     client_dir = (
         Path(__file__).parent.parent / "src/opnsense_openapi/generated" / f"v{version_module}"
     )
     has_tool = shutil.which("openapi-python-client") is not None
 
-    if client_dir.exists():
-        # Client already exists, should return True
-        assert result is True
-    elif has_tool:
-        # Tool is available and spec exists, should have generated and returned True
-        assert result is True
+    if client_dir.exists() or has_tool:
+        # Either the generated client is already present, or codegen will
+        # succeed: function should return the resolved version string.
+        result = _auto_generate_client("24.7.1")
+        assert result == "24.7.1"
     else:
-        # Tool is not available, should return False
-        assert result is False
+        # Spec exists but the tool is missing → CLI-missing error.
+        with pytest.raises(RuntimeError, match="openapi-python-client is not on PATH"):
+            _auto_generate_client("24.7.1")
 
 
 def test_api_property_no_spec_error_message() -> None:
-    """Test that api property provides helpful error when spec is missing."""
+    """Test that api property provides a spec-missing error when the spec is absent."""
     client = OPNsenseClient(
         base_url="https://opnsense.local",
         api_key="test_key",
@@ -191,6 +195,45 @@ def test_api_property_no_spec_error_message() -> None:
         _ = client.api
 
     error_msg = str(exc_info.value)
-    assert "No OpenAPI spec found" in error_msg
-    assert "opnsense-openapi download" in error_msg
-    assert "opnsense-openapi generate" in error_msg
+    assert "No OpenAPI spec for version 99.99.99" in error_msg
+    assert "opnsense-openapi generate 99.99.99" in error_msg
+
+
+def test_api_property_cli_missing_error_message(tmp_path: Path) -> None:
+    """Test that api property names the missing CLI rather than a phantom missing spec.
+
+    When the spec is present but ``openapi-python-client`` is not on PATH, the
+    error must say so and recommend the correct install command — not the
+    misleading "No OpenAPI spec found" message we used to surface.
+    """
+    from unittest.mock import patch
+
+    spec_path = tmp_path / "opnsense-24.7.1.json"
+    spec_path.write_text("{}")
+
+    client = OPNsenseClient(
+        base_url="https://opnsense.local",
+        api_key="test_key",
+        api_secret="test_secret",
+        spec_version="24.7.1",
+        auto_detect_version=False,
+    )
+
+    with (
+        patch(
+            "opnsense_openapi.client.base.find_best_matching_spec",
+            return_value=spec_path,
+        ),
+        # Ensure the generated client dir does not exist for this version,
+        # so the helper falls through to the shutil.which check.
+        patch("pathlib.Path.exists", return_value=False),
+        patch("opnsense_openapi.client.base.shutil.which", return_value=None),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        _ = client.api
+
+    error_msg = str(exc_info.value)
+    assert "openapi-python-client is not on PATH" in error_msg
+    assert "uv tool install openapi-python-client" in error_msg
+    # Must not regress to the old misleading "spec missing" wording.
+    assert "No OpenAPI spec for version" not in error_msg

--- a/tests/test_client_auto_generate.py
+++ b/tests/test_client_auto_generate.py
@@ -2,6 +2,10 @@
 
 These cover the module-level client auto-generation helper in isolation. Tests
 for ``OPNsenseClient`` itself are intentionally scoped to PR-b.
+
+The helper raises ``RuntimeError`` with a cause-tagged message for each of
+three distinct failure modes (spec missing, CLI missing, codegen failed) and
+returns the *resolved* spec version on success.
 """
 
 from __future__ import annotations
@@ -10,20 +14,34 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from opnsense_openapi.client.base import _auto_generate_client, _resolved_module_dir
 
 
-def test_auto_generate_returns_false_when_spec_missing() -> None:
-    """_auto_generate_client returns False if no spec file matches the version."""
-    with patch(
-        "opnsense_openapi.client.base.find_best_matching_spec",
-        side_effect=FileNotFoundError("no spec"),
+def test_auto_generate_raises_when_spec_missing() -> None:
+    """_auto_generate_client raises a spec-missing error when no spec resolves."""
+    with (
+        patch(
+            "opnsense_openapi.client.base.find_best_matching_spec",
+            side_effect=FileNotFoundError("no spec"),
+        ),
+        pytest.raises(RuntimeError) as exc_info,
     ):
-        assert _auto_generate_client("99.99") is False
+        _auto_generate_client("99.99")
+
+    msg = str(exc_info.value)
+    assert "No OpenAPI spec for version 99.99" in msg
+    assert "available=" in msg
+    assert "opnsense-openapi generate 99.99" in msg
 
 
-def test_auto_generate_returns_true_when_client_exists(tmp_path: Path) -> None:
-    """_auto_generate_client short-circuits when the generated client directory exists."""
+def test_auto_generate_returns_resolved_version_when_client_exists(tmp_path: Path) -> None:
+    """_auto_generate_client short-circuits when the generated client directory exists.
+
+    The return value is the *resolved* spec version (the version segment of
+    the spec filename), not the raw input.
+    """
     spec_path = tmp_path / "opnsense-24.7.json"
     spec_path.write_text("{}")
 
@@ -34,11 +52,11 @@ def test_auto_generate_returns_true_when_client_exists(tmp_path: Path) -> None:
         ),
         patch("pathlib.Path.exists", return_value=True),
     ):
-        assert _auto_generate_client("24.7") is True
+        assert _auto_generate_client("24.7") == "24.7"
 
 
-def test_auto_generate_returns_false_when_cli_missing(tmp_path: Path) -> None:
-    """_auto_generate_client returns False when openapi-python-client is absent."""
+def test_auto_generate_raises_when_cli_missing(tmp_path: Path) -> None:
+    """_auto_generate_client raises a CLI-missing error when openapi-python-client is absent."""
     spec_path = tmp_path / "opnsense-24.7.json"
     spec_path.write_text("{}")
 
@@ -50,12 +68,21 @@ def test_auto_generate_returns_false_when_cli_missing(tmp_path: Path) -> None:
         ),
         patch("pathlib.Path.exists", return_value=False),
         patch("shutil.which", return_value=None),
+        pytest.raises(RuntimeError) as exc_info,
     ):
-        assert _auto_generate_client("24.7") is False
+        _auto_generate_client("24.7")
+
+    msg = str(exc_info.value)
+    assert "openapi-python-client is not on PATH" in msg
+    assert "uv tool install openapi-python-client" in msg
+    assert str(spec_path) in msg
 
 
 def test_auto_generate_invokes_client_generator(tmp_path: Path) -> None:
-    """_auto_generate_client shells out to openapi-python-client with expected args."""
+    """_auto_generate_client shells out to openapi-python-client with expected args.
+
+    On success, returns the resolved spec version.
+    """
     spec_path = tmp_path / "opnsense-24.7.json"
     spec_path.write_text("{}")
 
@@ -68,7 +95,7 @@ def test_auto_generate_invokes_client_generator(tmp_path: Path) -> None:
         patch("shutil.which", return_value="/usr/bin/openapi-python-client"),
         patch("subprocess.check_call") as check_call,
     ):
-        assert _auto_generate_client("24.7") is True
+        assert _auto_generate_client("24.7") == "24.7"
 
     check_call.assert_called_once()
     cmd = check_call.call_args.args[0]
@@ -77,10 +104,12 @@ def test_auto_generate_invokes_client_generator(tmp_path: Path) -> None:
     assert str(spec_path) in cmd
 
 
-def test_auto_generate_returns_false_on_generator_failure(tmp_path: Path) -> None:
-    """_auto_generate_client returns False when the generator subprocess fails."""
+def test_auto_generate_raises_with_stderr_on_generator_failure(tmp_path: Path) -> None:
+    """_auto_generate_client raises a codegen-failed error containing the captured stderr."""
     spec_path = tmp_path / "opnsense-24.7.json"
     spec_path.write_text("{}")
+
+    captured_stderr = b"openapi-python-client: error: bad ref #/components/schemas/Foo"
 
     with (
         patch(
@@ -91,10 +120,19 @@ def test_auto_generate_returns_false_on_generator_failure(tmp_path: Path) -> Non
         patch("shutil.which", return_value="/usr/bin/openapi-python-client"),
         patch(
             "subprocess.check_call",
-            side_effect=subprocess.CalledProcessError(returncode=1, cmd=["x"]),
+            side_effect=subprocess.CalledProcessError(
+                returncode=2, cmd=["x"], stderr=captured_stderr
+            ),
         ),
+        pytest.raises(RuntimeError) as exc_info,
     ):
-        assert _auto_generate_client("24.7") is False
+        _auto_generate_client("24.7")
+
+    msg = str(exc_info.value)
+    assert "openapi-python-client failed for version 24.7" in msg
+    assert str(spec_path) in msg
+    assert "returncode=2" in msg
+    assert "bad ref #/components/schemas/Foo" in msg
 
 
 # --- Module-path stability across security-patch revisions ----------------
@@ -130,6 +168,8 @@ def test_auto_generate_skips_codegen_for_security_patch_revision(tmp_path: Path)
         2. Second call (raw version ``26.1.6_2``, same resolver target) —
            the canonical ``v26_1_6`` directory now exists, so codegen is
            **not** invoked again.
+
+    Both calls must return the resolved version (``"26.1.6"``).
     """
     spec_path = tmp_path / "opnsense-26.1.6.json"
     spec_path.write_text("{}")
@@ -157,9 +197,9 @@ def test_auto_generate_skips_codegen_for_security_patch_revision(tmp_path: Path)
         patch("subprocess.check_call", side_effect=fake_check_call) as check_call,
     ):
         # First call: no v26_1_6 dir yet → codegen runs.
-        assert _auto_generate_client("26.1.6") is True
+        assert _auto_generate_client("26.1.6") == "26.1.6"
         # Second call with security-patch suffix: short-circuits.
-        assert _auto_generate_client("26.1.6_2") is True
+        assert _auto_generate_client("26.1.6_2") == "26.1.6"
 
     # codegen invoked exactly once across both calls.
     assert check_call.call_count == 1


### PR DESCRIPTION
## Description

`OPNsenseClient.api` previously raised a single misleading error — `"No OpenAPI spec found"` — for three distinct failure modes. Users who had the spec but were missing the `openapi-python-client` binary on `PATH` saw a message blaming a spec they actually had, and users hitting an actual codegen failure got no useful diagnostic at all.

This PR distinguishes the three failure modes inside `_auto_generate_client()` and surfaces a cause-tagged `RuntimeError` for each, plus captures `openapi-python-client`'s `stderr` so a real codegen failure prints something actionable instead of being silent. The install hint everywhere is corrected from `uv pip install openapi-python-client` (which doesn't put the binary on `PATH` globally) to `uv tool install openapi-python-client`.

## Related Issue

Addresses #33

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

**`src/opnsense_openapi/client/base.py`:**
- `_auto_generate_client(version)` signature changed from `-> bool` to `-> str` (returns the resolved spec version, which the `api` property reuses to build the importlib path).
- Three distinct `RuntimeError` messages now identify the failure mode:
  - **Spec missing:** `"No OpenAPI spec for version {version}; available=[...]. Generate with: opnsense-openapi generate {version}"`
  - **CLI missing:** `"openapi-python-client is not on PATH; cannot generate the typed client for version {version} (spec found at {spec_path}). Install with \`uv tool install openapi-python-client\` and retry, or run \`opnsense-openapi generate {version}\` manually."`
  - **Codegen failed:** `"openapi-python-client failed for version {version} (spec={spec_path}, returncode={rc}). Re-run interactively for full output: opnsense-openapi generate {version}. Captured stderr: {stderr_text}"`
- Subprocess `stderr` is now captured (`stderr=subprocess.PIPE`) and surfaced in the codegen-failure message so the underlying cause is visible without re-running the command.
- Bonus simplification: the `api` property no longer re-calls `_resolved_module_dir()` after `_auto_generate_client()` already resolved the spec — the helper now returns the resolved version directly, removing a redundant lookup.
- The install hint string in the CLI-missing branch now reads `uv tool install openapi-python-client` (was `uv pip install`, which only installs into the current venv and does not put the binary on `PATH` globally).

**`src/opnsense_openapi/cli.py`:**
- Two install-hint strings (lines 344 and 478, in the `generate-client` and `build-client` commands) corrected from `uv pip install openapi-python-client` to `uv tool install openapi-python-client` for consistency with `client/base.py`.

**`tests/test_client.py`:**
- Auto-generate-client tests updated to assert the new exception types and message wording, and to reflect the `str` return value.
- New test asserts that `client.api` surfaces the CLI-missing message specifically (not the spec-missing one) when the spec is present but the binary is not on `PATH`.

**`tests/test_client_auto_generate.py`:**
- Five failure-mode tests rewritten for the new contract (spec missing / CLI missing / codegen failed each have explicit assertions on the message tag).
- Two security-patch tests reworked for the new signature.
- New test asserts that the codegen-failure message includes the captured `stderr` payload from the failed subprocess.

**No public API breakage:** `client.api` still raises `RuntimeError` on these failures — only the message wording changes. The internal `_auto_generate_client` signature change is module-private.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`uv run doit check` passes locally (format_check, lint, type_check, security, spell_check, test).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

No ADR needed — this is a bug fix to error reporting, not an architectural decision. No docs updates needed: a `grep` for `uv pip install openapi-python-client` across the repo confirms the wrong hint did not appear in `docs/` or `README.md`. The only generated-client-install references in user-facing docs are correct (`opnsense-openapi build-client`, etc.).
