### PR TITLE
fix: raise APIResponseError on non-JSON responses in post()

### DIFF
--- a/src/opnsense_openapi/client/base.py
+++ b/src/opnsense_openapi/client/base.py
@@ -7,6 +7,7 @@ import json
 import logging
 import shutil
 import subprocess  # nosec B404 - invoked only via shutil.which-validated entry point
+from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urljoin
@@ -281,7 +282,7 @@ class OPNsenseClient:
         response.raise_for_status()
         try:
             return cast(dict[str, Any], response.json())
-        except json.JSONDecodeError as e:
+        except JSONDecodeError as e:
             raise APIResponseError(f"Invalid JSON response from {url}: {e}", response.text) from e
 
     def post(
@@ -315,7 +316,7 @@ class OPNsenseClient:
         response.raise_for_status()
         try:
             return cast(dict[str, Any], response.json())
-        except json.JSONDecodeError as e:  # type: ignore[union-attr]
+        except JSONDecodeError as e:
             raise APIResponseError(f"Invalid JSON response from {url}: {e}", response.text) from e
 
     def close(self) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -140,6 +140,40 @@ def test_api_response_error() -> None:
     assert error.response_text == "<html>Error</html>"
 
 
+def test_post_non_json_response_raises_api_response_error() -> None:
+    """post() must raise APIResponseError (not AttributeError) on non-JSON responses.
+
+    Regression test for #44: the ``json`` parameter of ``post()`` previously
+    shadowed the ``json`` module, so the ``except json.JSONDecodeError`` clause
+    raised ``AttributeError`` instead of the documented ``APIResponseError``.
+    """
+    import json as _json
+    from unittest.mock import MagicMock
+
+    from opnsense_openapi.client.base import APIResponseError
+
+    client = OPNsenseClient(
+        base_url="https://opnsense.local",
+        api_key="k",
+        api_secret="s",
+        auto_detect_version=False,
+    )
+
+    fake_response = MagicMock()
+    fake_response.text = "<html>not json</html>"
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json = MagicMock(
+        side_effect=_json.JSONDecodeError("Expecting value", "<html>not json</html>", 0)
+    )
+    client._client.post = MagicMock(return_value=fake_response)  # type: ignore[method-assign]
+
+    with pytest.raises(APIResponseError) as exc_info:
+        client.post("module", "controller", "command", json={"k": "v"})
+
+    assert "Invalid JSON response" in str(exc_info.value)
+    assert exc_info.value.response_text == "<html>not json</html>"
+
+
 def test_auto_generate_client_spec_missing() -> None:
     """Test auto-generation raises a spec-missing RuntimeError when no spec exists."""
     from opnsense_openapi.client.base import _auto_generate_client


### PR DESCRIPTION
## Description

Fixes a name-shadowing bug in `OPNsenseClient.post()` that caused non-JSON responses to surface as `AttributeError` instead of the documented `APIResponseError`.

The `post()` method takes a parameter named `json`, which shadows the `json` module imported at the top of `client/base.py`. The `except json.JSONDecodeError` clause inside `post()` therefore tried to look up `JSONDecodeError` on the parameter value (a dict or `None`) rather than on the module, raising `AttributeError` whenever the response was not valid JSON. A `# type: ignore[union-attr]` comment on that except clause was masking the type-checker's warning about this.

The fix imports `JSONDecodeError` directly at module scope (`from json import JSONDecodeError`) and updates both `get()` and `post()` to reference the unbound name. The lookup no longer touches the `json` module, so the parameter name no longer interferes. The misleading `# type: ignore` is removed.

Discovered while writing PR-b coverage tests for #6; the test that pinned the bug behaviour is parked on `chore/6-coverage-pr-b` and will be updated post-merge.

## Related Issue

Addresses #44

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

Not a breaking change at the public API: `post()`'s signature is unchanged. The only behavioural change is that non-JSON responses now raise `APIResponseError` (the documented type) instead of `AttributeError`, which matches the docstring.

## Changes Made

- `src/opnsense_openapi/client/base.py`: add `from json import JSONDecodeError`; switch both `except` clauses (in `get()` and `post()`) to the unbound name; drop the `# type: ignore[union-attr]` that was masking the bug.
- `tests/test_client.py`: add `test_post_non_json_response_raises_api_response_error` regression test that mocks `httpx.Client.post` so `.json()` raises `JSONDecodeError`, and asserts `APIResponseError` is raised carrying the response text.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes locally (format, lint, type-check, security, spell-check, test).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly (no docs changes needed — internal exception handling)
- [ ] I have updated the CHANGELOG.md (auto-generated by commitizen on release)
- [x] My changes generate no new warnings

## Additional Notes

No ADR required: the issue is not labeled `needs-adr` and the fix is not architectural.
