### PR TITLE
chore: sync AI hooks to pyproject-template (PR 2 of 4)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "env": {
+    "ENABLE_PROMPT_CACHING_1H": "1",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-4-6"
+  },
   "statusLine": {
     "type": "command",
     "command": "bash $CLAUDE_PROJECT_DIR/.claude/statusline-command.sh"
@@ -7,6 +12,15 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/block-dangerous-commands.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -22,6 +36,28 @@
           {
             "type": "command",
             "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/ruff-fix-on-edit.py"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "timeout": 90,
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/precompact-checkpoint.py"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/session-resume-restore.py"
           }
         ]
       }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -28,6 +28,21 @@ timeout = 30
 statusMessage = "Checking Bash command"
 
 # =============================================================================
+# FILE-EDIT HOOK — Blocks env-var persistence attempts
+# =============================================================================
+# Fires before Edit, Write, and MultiEdit to prevent AI from persisting
+# governance bypass env vars to shell or project config files.
+# See: docs/development/ai/command-blocking.md
+[[hooks.PreToolUse]]
+matcher = "^(Edit|Write|MultiEdit)$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = 'python3 "$(git rev-parse --show-toplevel)/tools/hooks/ai/block-dangerous-commands.py"'
+timeout = 30
+statusMessage = "Checking file edit"
+
+# =============================================================================
 # SHELL ENVIRONMENT POLICY
 # =============================================================================
 [shell_environment_policy]

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -12,6 +12,15 @@
             "command": "python3 $GEMINI_PROJECT_DIR/tools/hooks/ai/block-dangerous-commands.py"
           }
         ]
+      },
+      {
+        "matcher": "write_file|replace",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $GEMINI_PROJECT_DIR/tools/hooks/ai/block-dangerous-commands.py"
+          }
+        ]
       }
     ]
   },

--- a/tests/test_bash_ban_raw_tools.py
+++ b/tests/test_bash_ban_raw_tools.py
@@ -1,0 +1,334 @@
+"""Tests for the ``bash-ban-raw-tools`` PreToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/bash-ban-raw-tools.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "bash-ban-raw-tools.py"
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("bash_ban_raw_tools", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["bash_ban_raw_tools"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("bash_ban_raw_tools", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _bash_payload(command: str, cwd: str | None = None) -> str:
+    """Build a Bash tool payload for the given command.
+
+    If *cwd* is provided it is included in the payload so the hook can resolve
+    the per-project unlock path without relying on ``CLAUDE_PROJECT_DIR``.
+    """
+    data: dict[str, object] = {"tool_name": "Bash", "tool_input": {"command": command}}
+    if cwd is not None:
+        data["cwd"] = cwd
+    return json.dumps(data)
+
+
+def _non_bash_payload(tool_name: str) -> str:
+    """Build a non-Bash tool payload."""
+    return json.dumps({"tool_name": tool_name, "tool_input": {"file_path": "README.md"}})
+
+
+def _make_unlock(project_root: Path) -> Path:
+    """Create the per-project unlock file and return its path."""
+    unlock = project_root / "tmp" / "agents" / "claude" / "bash-raw-unlock"
+    unlock.parent.mkdir(parents=True, exist_ok=True)
+    unlock.touch()
+    return unlock
+
+
+# ---------------------------------------------------------------------------
+# Allow cases
+# ---------------------------------------------------------------------------
+
+
+def test_non_bash_tool_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-Bash tools (e.g. Read) are always allowed."""
+    _set_stdin(monkeypatch, _non_bash_payload("Read"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_benign_bash_command_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Safe Bash commands like ``ls -la`` are allowed."""
+    _set_stdin(monkeypatch, _bash_payload("ls -la"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_malformed_json_exits_1(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed JSON input exits with code 1 (parity with block-dangerous-commands)."""
+    _set_stdin(monkeypatch, "not valid json{{")
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 1
+
+
+def test_banned_word_as_non_leading_non_pipe_token_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``echo cat`` — banned word is not the leading token and not after a pipe."""
+    _set_stdin(monkeypatch, _bash_payload("echo cat"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ls | head",
+        "ls | tail -100",
+        "cmd | head -n 5",
+    ],
+)
+def test_piped_truncator_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    """Piped truncators (``... | head``, ``... | tail``) are allowed — no native replacement."""
+    _set_stdin(monkeypatch, _bash_payload(command))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Block: banned leading commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat README.md",
+        "head foo.txt",
+        "tail -f log.txt",
+        "find . -name '*.py'",
+        "grep pattern file.py",
+        "rg pattern",
+        "wc -l file.txt",
+    ],
+)
+def test_banned_leading_command_exits_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    """Each banned leading command is blocked with exit code 2."""
+    _set_stdin(monkeypatch, _bash_payload(command))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Escape hatch: unlock file
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_unlock_file_allows_banned_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When unlock file exists and mtime is within window, banned commands are allowed."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    _make_unlock(tmp_path)
+
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(tmp_path)))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_stale_unlock_file_blocks_banned_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When unlock file mtime is older than UNLOCK_WINDOW_SECONDS, command is blocked."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    unlock = _make_unlock(tmp_path)
+    # Set mtime to well past the window
+    stale_mtime = time.time() - (hook.UNLOCK_WINDOW_SECONDS + 60)
+    os.utime(str(unlock), (stale_mtime, stale_mtime))
+
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(tmp_path)))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+def test_missing_unlock_file_blocks_banned_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When unlock file does not exist, banned commands are blocked."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    # Do NOT create the file; just pass a valid cwd so path resolution works
+
+    _set_stdin(monkeypatch, _bash_payload("grep pattern file.py", cwd=str(tmp_path)))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Stderr reason content checks
+# ---------------------------------------------------------------------------
+
+
+def test_stderr_reason_mentions_offending_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stderr block reason mentions the offending command."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(tmp_path)))
+
+    with pytest.raises(SystemExit):
+        sys.exit(hook.main())
+
+    captured = capsys.readouterr()
+    assert "cat" in captured.err
+
+
+def test_stderr_reason_mentions_unlock_file(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stderr block reason mentions the escape hatch (per-project unlock path)."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(tmp_path)))
+
+    with pytest.raises(SystemExit):
+        sys.exit(hook.main())
+
+    captured = capsys.readouterr()
+    expected_path = str(tmp_path / "tmp" / "agents" / "claude" / "bash-raw-unlock")
+    assert expected_path in captured.err
+
+
+# ---------------------------------------------------------------------------
+# New tests: per-project isolation, fail-closed, env precedence
+# ---------------------------------------------------------------------------
+
+
+def test_unlock_file_in_one_project_does_not_unlock_another(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unlock file in project_a does NOT unlock commands run with cwd=project_b."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    project_a = tmp_path / "project_a"
+    project_b = tmp_path / "project_b"
+    project_a.mkdir()
+    project_b.mkdir()
+
+    # Touch unlock in project_a only
+    _make_unlock(project_a)
+
+    # Run hook as if we're in project_b — should still be blocked
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(project_b)))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+def test_no_project_dir_blocks_with_unlock_unavailable_message(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No CLAUDE_PROJECT_DIR and no cwd: command is blocked; stderr says hatch unavailable."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    # No cwd in payload
+    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "unavailable" in captured.err.lower() or "project root" in captured.err.lower()
+
+
+def test_claude_project_dir_env_overrides_cwd(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """CLAUDE_PROJECT_DIR env var wins over cwd in the payload."""
+    project_a = tmp_path / "project_a"
+    project_b = tmp_path / "project_b"
+    project_a.mkdir()
+    project_b.mkdir()
+
+    # Unlock only in project_a; env points to project_a; cwd points to project_b
+    _make_unlock(project_a)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_a))
+
+    # Even though cwd is project_b, env var should win → allowed
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(project_b)))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0

--- a/tests/test_hook_cbm_code_discovery_gate.py
+++ b/tests/test_hook_cbm_code_discovery_gate.py
@@ -1,0 +1,320 @@
+"""Tests for the ``cbm-code-discovery-gate`` PreToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/cbm-code-discovery-gate.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "cbm-code-discovery-gate.py"
+)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("cbm_code_discovery_gate", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["cbm_code_discovery_gate"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("cbm_code_discovery_gate", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _read_payload(path: str) -> str:
+    """Build a Read tool payload for the given path."""
+    return json.dumps({"tool_name": "Read", "tool_input": {"file_path": path}})
+
+
+def _grep_payload(path: str | None = None) -> str:
+    """Build a Grep tool payload. If path is None, simulate a whole-repo search."""
+    tool_input: dict[str, str] = {}
+    if path is not None:
+        tool_input["path"] = path
+    return json.dumps({"tool_name": "Grep", "tool_input": tool_input})
+
+
+def _glob_payload(path: str | None = None) -> str:
+    """Build a Glob tool payload. If path is None, simulate a whole-repo search."""
+    tool_input: dict[str, str] = {}
+    if path is not None:
+        tool_input["path"] = path
+    return json.dumps({"tool_name": "Glob", "tool_input": tool_input})
+
+
+def _non_gated_payload(tool_name: str) -> str:
+    """Build a non-gated tool payload."""
+    return json.dumps({"tool_name": tool_name, "tool_input": {"command": "ls -la"}})
+
+
+# ---------------------------------------------------------------------------
+# Allow cases: non-gated tool
+# ---------------------------------------------------------------------------
+
+
+def test_non_gated_tool_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-gated tools (e.g. Bash) are always allowed — gate only applies to Read/Grep/Glob."""
+    _set_stdin(monkeypatch, _non_gated_payload("Bash"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Allow cases: allow-list extension matches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "pyproject.toml",
+        "README.md",
+        "requirements.txt",
+        "config.yaml",
+        "config.yml",
+        "data.json",
+        "poetry.lock",
+        ".env",
+        "setup.sh",
+    ],
+)
+def test_allowlist_extension_allows_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+) -> None:
+    """Read on an allow-listed extension always passes through."""
+    _set_stdin(monkeypatch, _read_payload(path))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Allow cases: allow-list path fragment matches
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_claude_dir_allows_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Read on a .claude/ path always passes through."""
+    _set_stdin(monkeypatch, _read_payload(".claude/settings.json"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_allowlist_tests_dir_allows_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Read on a tests/ path always passes through."""
+    _set_stdin(monkeypatch, _read_payload("tests/test_foo.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_allowlist_hooks_dir_allows_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Read on a hooks/ path always passes through."""
+    _set_stdin(monkeypatch, _read_payload("tools/hooks/ai/bash-ban-raw-tools.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_allowlist_grep_on_docs_allows(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Grep on a .md file (docs) always passes through."""
+    _set_stdin(monkeypatch, _grep_payload("docs/foo.md"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Allow cases: fresh CBM marker
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_marker_allows_source_file_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Read on a source file is allowed when the CBM marker is fresh."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    marker = tmp_path / f"marker-{os.getppid()}"
+    marker.touch()
+
+    _set_stdin(monkeypatch, _read_payload("src/main.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Block cases: source file without fresh marker
+# ---------------------------------------------------------------------------
+
+
+def test_missing_marker_blocks_source_file_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Read on a source file is blocked when the CBM marker does not exist."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    # Do NOT create the marker file.
+
+    _set_stdin(monkeypatch, _read_payload("src/main.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+def test_stale_marker_blocks_source_file_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Read on a source file is blocked when the CBM marker mtime is older than TTL."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    marker = tmp_path / f"marker-{os.getppid()}"
+    marker.touch()
+    stale_mtime = time.time() - (hook.MARKER_TTL_SECONDS + 60)
+    os.utime(str(marker), (stale_mtime, stale_mtime))
+
+    _set_stdin(monkeypatch, _read_payload("src/main.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+def test_whole_repo_grep_no_marker_is_blocked(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Grep with no path (whole-repo) is blocked when no CBM marker exists."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    # No marker file.
+
+    _set_stdin(monkeypatch, _grep_payload(None))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+def test_whole_repo_glob_no_marker_is_blocked(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Glob with no path (whole-repo) is blocked when no CBM marker exists."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    # No marker file.
+
+    _set_stdin(monkeypatch, _glob_payload(None))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Stderr content checks
+# ---------------------------------------------------------------------------
+
+
+def test_stderr_mentions_gated_tool(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stderr block reason names the gated tool."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    _set_stdin(monkeypatch, _read_payload("src/main.py"))
+
+    with pytest.raises(SystemExit):
+        sys.exit(hook.main())
+
+    captured = capsys.readouterr()
+    assert "Read" in captured.err
+
+
+def test_stderr_mentions_marker_path(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stderr block reason references the CBM marker mechanism."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    _set_stdin(monkeypatch, _read_payload("src/main.py"))
+
+    with pytest.raises(SystemExit):
+        sys.exit(hook.main())
+
+    captured = capsys.readouterr()
+    # The marker path (with ppid filled in) should appear in stderr.
+    assert str(tmp_path) in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Malformed JSON
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_exits_1(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed JSON input exits with code 1 (parity with bash-ban-raw-tools)."""
+    _set_stdin(monkeypatch, "not valid json{{")
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 1

--- a/tests/test_hook_cbm_mcp_marker.py
+++ b/tests/test_hook_cbm_mcp_marker.py
@@ -1,0 +1,155 @@
+"""Tests for the ``cbm-mcp-marker`` PostToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/cbm-mcp-marker.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "cbm-mcp-marker.py"
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("cbm_mcp_marker", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["cbm_mcp_marker"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("cbm_mcp_marker", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _cbm_tool_payload(tool_name: str = "mcp__codebase-memory__search_graph") -> str:
+    """Build a typical PostToolUse payload for a CBM MCP tool call."""
+    return json.dumps(
+        {
+            "tool_name": tool_name,
+            "tool_input": {"query": "find main function"},
+            "tool_response": {"result": "..."},
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Marker file creation
+# ---------------------------------------------------------------------------
+
+
+def test_marker_file_is_created(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Marker file is created when it does not already exist."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    marker = tmp_path / f"marker-{os.getppid()}"
+    assert not marker.exists()
+
+    _set_stdin(monkeypatch, _cbm_tool_payload())
+    assert hook.main() == 0
+
+    assert marker.exists()
+
+
+def test_marker_file_mtime_is_fresh(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Marker file mtime is within 5 seconds of now after hook runs."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    marker = tmp_path / f"marker-{os.getppid()}"
+
+    before = time.time()
+    _set_stdin(monkeypatch, _cbm_tool_payload())
+    assert hook.main() == 0
+    after = time.time()
+
+    mtime = marker.stat().st_mtime
+    assert before - 1 <= mtime <= after + 1
+
+
+def test_marker_file_mtime_is_updated(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Marker file mtime is updated when the file already exists."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    marker = tmp_path / f"marker-{os.getppid()}"
+    marker.touch()
+    old_mtime = time.time() - 60
+    os.utime(str(marker), (old_mtime, old_mtime))
+
+    _set_stdin(monkeypatch, _cbm_tool_payload())
+    assert hook.main() == 0
+
+    new_mtime = marker.stat().st_mtime
+    assert new_mtime > old_mtime
+
+
+# ---------------------------------------------------------------------------
+# Marker path uses MARKER_FILE_TEMPLATE
+# ---------------------------------------------------------------------------
+
+
+def test_marker_path_uses_configured_template(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Marker is created at the path derived from MARKER_FILE_TEMPLATE."""
+    custom_template = str(tmp_path / "custom-marker-{ppid}")
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", custom_template)
+    expected_marker = tmp_path / f"custom-marker-{os.getppid()}"
+
+    _set_stdin(monkeypatch, _cbm_tool_payload())
+    assert hook.main() == 0
+
+    assert expected_marker.exists()
+
+
+# ---------------------------------------------------------------------------
+# Malformed JSON: best-effort, no crash
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed JSON exits 0 — the marker hook never blocks (best-effort)."""
+    _set_stdin(monkeypatch, "not valid json{{")
+    assert hook.main() == 0

--- a/tests/test_hook_cbm_session_reminder.py
+++ b/tests/test_hook_cbm_session_reminder.py
@@ -1,0 +1,179 @@
+"""Tests for the ``cbm-session-reminder`` SessionStart hook.
+
+The hook script lives at ``tools/hooks/ai/cbm-session-reminder.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "cbm-session-reminder.py"
+)
+
+# Sibling reminder file (used to verify real content in integration-style tests).
+REAL_REMINDER_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "cbm-session-reminder.md"
+)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("cbm_session_reminder", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["cbm_session_reminder"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("cbm_session_reminder", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _session_start_payload(trigger: str = "compact") -> str:
+    """Build a SessionStart payload with the given trigger."""
+    return json.dumps({"trigger": trigger, "cwd": "/some/project"})
+
+
+# ---------------------------------------------------------------------------
+# Stdout JSON shape
+# ---------------------------------------------------------------------------
+
+
+def test_stdout_is_valid_json(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Hook emits valid JSON on stdout."""
+    reminder = tmp_path / "reminder.md"
+    reminder.write_text("# Reminder\nUse CBM tools.", encoding="utf-8")
+    monkeypatch.setattr(hook, "REMINDER_TEXT_PATH", reminder)
+
+    _set_stdin(monkeypatch, _session_start_payload())
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert isinstance(data, dict)
+
+
+def test_stdout_hook_event_name_is_session_start(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """hookSpecificOutput.hookEventName is 'SessionStart'."""
+    reminder = tmp_path / "reminder.md"
+    reminder.write_text("# Reminder\nUse CBM tools.", encoding="utf-8")
+    monkeypatch.setattr(hook, "REMINDER_TEXT_PATH", reminder)
+
+    _set_stdin(monkeypatch, _session_start_payload())
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+
+
+def test_stdout_additional_context_matches_reminder_file(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """additionalContext equals the full contents of the reminder file."""
+    reminder_body = "# CBM Reminder\nUse search_graph first.\n"
+    reminder = tmp_path / "reminder.md"
+    reminder.write_text(reminder_body, encoding="utf-8")
+    monkeypatch.setattr(hook, "REMINDER_TEXT_PATH", reminder)
+
+    _set_stdin(monkeypatch, _session_start_payload())
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["hookSpecificOutput"]["additionalContext"] == reminder_body
+
+
+# ---------------------------------------------------------------------------
+# Real reminder file integration
+# ---------------------------------------------------------------------------
+
+
+def test_real_reminder_file_produces_non_empty_context(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The shipped cbm-session-reminder.md produces non-empty additionalContext."""
+    # Uses the real REMINDER_TEXT_PATH from the hook (no monkeypatch needed).
+    _set_stdin(monkeypatch, _session_start_payload())
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert len(data["hookSpecificOutput"]["additionalContext"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Missing reminder file: degrade gracefully
+# ---------------------------------------------------------------------------
+
+
+def test_missing_reminder_file_exits_0_no_stdout(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When reminder file is missing, hook exits 0 and produces no stdout."""
+    monkeypatch.setattr(hook, "REMINDER_TEXT_PATH", tmp_path / "nonexistent.md")
+
+    _set_stdin(monkeypatch, _session_start_payload())
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Malformed JSON: best-effort, no crash
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed JSON exits 0 — the reminder hook never blocks (best-effort)."""
+    _set_stdin(monkeypatch, "not valid json{{")
+    assert hook.main() == 0

--- a/tests/test_hook_context_mode_posttooluse.py
+++ b/tests/test_hook_context_mode_posttooluse.py
@@ -1,0 +1,233 @@
+"""Tests for the ``context-mode-posttooluse`` PostToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/context-mode-posttooluse.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "context-mode-posttooluse.py"
+)
+
+
+class _BytesStdin:
+    """Minimal stdin stub whose .buffer attribute is a BytesIO."""
+
+    def __init__(self, data: bytes) -> None:
+        self.buffer = io.BytesIO(data)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("context_mode_posttooluse", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["context_mode_posttooluse"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("context_mode_posttooluse", None)
+
+
+# ---------------------------------------------------------------------------
+# CLI not installed: exit 0, subprocess never called
+# ---------------------------------------------------------------------------
+
+
+def test_cli_not_installed_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When shutil.which returns None, main() returns 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b'{"tool_name":"Bash"}'))
+    assert hook.main() == 0
+
+
+def test_cli_not_installed_subprocess_not_called(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When CLI is not installed, subprocess.run is never invoked."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    run_mock = MagicMock()
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+    hook.main()
+    run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI installed: correct invocation and stdout passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_cli_installed_calls_subprocess_with_correct_args(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """subprocess.run is called with [CLI_NAME, 'hook', 'claude-code', EVENT_NAME]."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    payload = b'{"tool_name":"Bash"}'
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(payload))
+
+    mock_result = subprocess.CompletedProcess(
+        args=[hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        returncode=0,
+        stdout=b"ok",
+        stderr=b"",
+    )
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=payload,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_installed_stdout_passthrough(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stdout bytes from subprocess are written to sys.stdout.buffer."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    captured_stdout = io.BytesIO()
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = captured_stdout
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    mock_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"summary output",
+        stderr=b"",
+    )
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+
+    assert hook.main() == 0
+    assert captured_stdout.getvalue() == b"summary output"
+
+
+def test_cli_installed_returns_subprocess_returncode(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates the subprocess exit code."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 1
+
+
+def test_cli_installed_returncode_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates returncode 2."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=2, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 2
+
+
+def test_subprocess_file_not_found_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FileNotFoundError from subprocess.run exits 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(side_effect=FileNotFoundError))
+    assert hook.main() == 0
+
+
+def test_empty_stdin_calls_subprocess(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty stdin still calls subprocess with input=b'' and propagates returncode."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b""))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=b"",
+        capture_output=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_event_name_constant(hook: types.ModuleType) -> None:
+    """EVENT_NAME is 'PostToolUse'."""
+    assert hook.EVENT_NAME == "PostToolUse"
+
+
+def test_cli_name_constant(hook: types.ModuleType) -> None:
+    """CLI_NAME is 'context-mode'."""
+    assert hook.CLI_NAME == "context-mode"

--- a/tests/test_hook_context_mode_precompact.py
+++ b/tests/test_hook_context_mode_precompact.py
@@ -1,0 +1,233 @@
+"""Tests for the ``context-mode-precompact`` PreCompact hook.
+
+The hook script lives at ``tools/hooks/ai/context-mode-precompact.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "context-mode-precompact.py"
+)
+
+
+class _BytesStdin:
+    """Minimal stdin stub whose .buffer attribute is a BytesIO."""
+
+    def __init__(self, data: bytes) -> None:
+        self.buffer = io.BytesIO(data)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("context_mode_precompact", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["context_mode_precompact"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("context_mode_precompact", None)
+
+
+# ---------------------------------------------------------------------------
+# CLI not installed: exit 0, subprocess never called
+# ---------------------------------------------------------------------------
+
+
+def test_cli_not_installed_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When shutil.which returns None, main() returns 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b'{"trigger":"compact"}'))
+    assert hook.main() == 0
+
+
+def test_cli_not_installed_subprocess_not_called(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When CLI is not installed, subprocess.run is never invoked."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    run_mock = MagicMock()
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+    hook.main()
+    run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI installed: correct invocation and stdout passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_cli_installed_calls_subprocess_with_correct_args(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """subprocess.run is called with [CLI_NAME, 'hook', 'claude-code', EVENT_NAME]."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    payload = b'{"trigger":"compact"}'
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(payload))
+
+    mock_result = subprocess.CompletedProcess(
+        args=[hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        returncode=0,
+        stdout=b"ok",
+        stderr=b"",
+    )
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=payload,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_installed_stdout_passthrough(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stdout bytes from subprocess are written to sys.stdout.buffer."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    captured_stdout = io.BytesIO()
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = captured_stdout
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    mock_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"summary output",
+        stderr=b"",
+    )
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+
+    assert hook.main() == 0
+    assert captured_stdout.getvalue() == b"summary output"
+
+
+def test_cli_installed_returns_subprocess_returncode(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates the subprocess exit code."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 1
+
+
+def test_cli_installed_returncode_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates returncode 2."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=2, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 2
+
+
+def test_subprocess_file_not_found_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FileNotFoundError from subprocess.run exits 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(side_effect=FileNotFoundError))
+    assert hook.main() == 0
+
+
+def test_empty_stdin_calls_subprocess(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty stdin still calls subprocess with input=b'' and propagates returncode."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b""))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=b"",
+        capture_output=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_event_name_constant(hook: types.ModuleType) -> None:
+    """EVENT_NAME is 'PreCompact'."""
+    assert hook.EVENT_NAME == "PreCompact"
+
+
+def test_cli_name_constant(hook: types.ModuleType) -> None:
+    """CLI_NAME is 'context-mode'."""
+    assert hook.CLI_NAME == "context-mode"

--- a/tests/test_hook_context_mode_pretooluse.py
+++ b/tests/test_hook_context_mode_pretooluse.py
@@ -1,0 +1,233 @@
+"""Tests for the ``context-mode-pretooluse`` PreToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/context-mode-pretooluse.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "context-mode-pretooluse.py"
+)
+
+
+class _BytesStdin:
+    """Minimal stdin stub whose .buffer attribute is a BytesIO."""
+
+    def __init__(self, data: bytes) -> None:
+        self.buffer = io.BytesIO(data)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("context_mode_pretooluse", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["context_mode_pretooluse"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("context_mode_pretooluse", None)
+
+
+# ---------------------------------------------------------------------------
+# CLI not installed: exit 0, subprocess never called
+# ---------------------------------------------------------------------------
+
+
+def test_cli_not_installed_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When shutil.which returns None, main() returns 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b'{"tool_name":"Bash"}'))
+    assert hook.main() == 0
+
+
+def test_cli_not_installed_subprocess_not_called(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When CLI is not installed, subprocess.run is never invoked."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    run_mock = MagicMock()
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+    hook.main()
+    run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI installed: correct invocation and stdout passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_cli_installed_calls_subprocess_with_correct_args(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """subprocess.run is called with [CLI_NAME, 'hook', 'claude-code', EVENT_NAME]."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    payload = b'{"tool_name":"Bash"}'
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(payload))
+
+    mock_result = subprocess.CompletedProcess(
+        args=[hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        returncode=0,
+        stdout=b"ok",
+        stderr=b"",
+    )
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=payload,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_installed_stdout_passthrough(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stdout bytes from subprocess are written to sys.stdout.buffer."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    captured_stdout = io.BytesIO()
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = captured_stdout
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    mock_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"summary output",
+        stderr=b"",
+    )
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+
+    assert hook.main() == 0
+    assert captured_stdout.getvalue() == b"summary output"
+
+
+def test_cli_installed_returns_subprocess_returncode(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates the subprocess exit code."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 1
+
+
+def test_cli_installed_returncode_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates returncode 2."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=2, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 2
+
+
+def test_subprocess_file_not_found_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FileNotFoundError from subprocess.run exits 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(side_effect=FileNotFoundError))
+    assert hook.main() == 0
+
+
+def test_empty_stdin_calls_subprocess(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty stdin still calls subprocess with input=b'' and propagates returncode."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b""))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=b"",
+        capture_output=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_event_name_constant(hook: types.ModuleType) -> None:
+    """EVENT_NAME is 'PreToolUse'."""
+    assert hook.EVENT_NAME == "PreToolUse"
+
+
+def test_cli_name_constant(hook: types.ModuleType) -> None:
+    """CLI_NAME is 'context-mode'."""
+    assert hook.CLI_NAME == "context-mode"

--- a/tests/test_hook_context_mode_sessionstart.py
+++ b/tests/test_hook_context_mode_sessionstart.py
@@ -1,0 +1,233 @@
+"""Tests for the ``context-mode-sessionstart`` SessionStart hook.
+
+The hook script lives at ``tools/hooks/ai/context-mode-sessionstart.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "context-mode-sessionstart.py"
+)
+
+
+class _BytesStdin:
+    """Minimal stdin stub whose .buffer attribute is a BytesIO."""
+
+    def __init__(self, data: bytes) -> None:
+        self.buffer = io.BytesIO(data)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("context_mode_sessionstart", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["context_mode_sessionstart"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("context_mode_sessionstart", None)
+
+
+# ---------------------------------------------------------------------------
+# CLI not installed: exit 0, subprocess never called
+# ---------------------------------------------------------------------------
+
+
+def test_cli_not_installed_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When shutil.which returns None, main() returns 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b'{"trigger":"startup"}'))
+    assert hook.main() == 0
+
+
+def test_cli_not_installed_subprocess_not_called(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When CLI is not installed, subprocess.run is never invoked."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    run_mock = MagicMock()
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+    hook.main()
+    run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI installed: correct invocation and stdout passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_cli_installed_calls_subprocess_with_correct_args(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """subprocess.run is called with [CLI_NAME, 'hook', 'claude-code', EVENT_NAME]."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    payload = b'{"trigger":"startup"}'
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(payload))
+
+    mock_result = subprocess.CompletedProcess(
+        args=[hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        returncode=0,
+        stdout=b"ok",
+        stderr=b"",
+    )
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=payload,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_installed_stdout_passthrough(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stdout bytes from subprocess are written to sys.stdout.buffer."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    captured_stdout = io.BytesIO()
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = captured_stdout
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    mock_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"summary output",
+        stderr=b"",
+    )
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+
+    assert hook.main() == 0
+    assert captured_stdout.getvalue() == b"summary output"
+
+
+def test_cli_installed_returns_subprocess_returncode(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates the subprocess exit code."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 1
+
+
+def test_cli_installed_returncode_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates returncode 2."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=2, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 2
+
+
+def test_subprocess_file_not_found_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FileNotFoundError from subprocess.run exits 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(side_effect=FileNotFoundError))
+    assert hook.main() == 0
+
+
+def test_empty_stdin_calls_subprocess(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty stdin still calls subprocess with input=b'' and propagates returncode."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b""))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=b"",
+        capture_output=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_event_name_constant(hook: types.ModuleType) -> None:
+    """EVENT_NAME is 'SessionStart'."""
+    assert hook.EVENT_NAME == "SessionStart"
+
+
+def test_cli_name_constant(hook: types.ModuleType) -> None:
+    """CLI_NAME is 'context-mode'."""
+    assert hook.CLI_NAME == "context-mode"

--- a/tests/test_hook_context_mode_test_runner_reminder.py
+++ b/tests/test_hook_context_mode_test_runner_reminder.py
@@ -1,0 +1,244 @@
+"""Tests for the ``context-mode-test-runner-reminder`` PreToolUse advisory hook.
+
+The hook script lives at ``tools/hooks/ai/context-mode-test-runner-reminder.py``. Its
+filename contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "tools"
+    / "hooks"
+    / "ai"
+    / "context-mode-test-runner-reminder.py"
+)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("context_mode_test_runner_reminder", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["context_mode_test_runner_reminder"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("context_mode_test_runner_reminder", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _bash_payload(command: str) -> str:
+    """Build a PreToolUse Bash payload for the given command string."""
+    return json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+
+
+# ---------------------------------------------------------------------------
+# Reminder emitted for test commands
+# ---------------------------------------------------------------------------
+
+
+def test_pytest_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """pytest command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("pytest -v tests/"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["hookSpecificOutput"]["additionalContext"] == hook.REMINDER
+
+
+def test_npm_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """npm test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("npm test"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+def test_npm_run_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """npm run test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("npm run test"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+def test_go_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """go test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("go test ./..."))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+def test_cargo_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """cargo test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("cargo test"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+def test_mvn_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """mvn test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("mvn test"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+def test_gradle_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """gradle test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("gradle test --info"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+# ---------------------------------------------------------------------------
+# No reminder for non-test commands
+# ---------------------------------------------------------------------------
+
+
+def test_ls_command_no_output(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-test command produces no stdout output."""
+    _set_stdin(monkeypatch, _bash_payload("ls -la"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_read_tool_no_output(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-Bash tool name produces no stdout output."""
+    payload = json.dumps({"tool_name": "Read", "tool_input": {"file_path": "/some/file.py"}})
+    _set_stdin(monkeypatch, payload)
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: malformed / empty input
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_exits_0_no_output(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Malformed JSON stdin exits 0 and produces no stdout."""
+    _set_stdin(monkeypatch, "not valid json{{")
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_empty_tool_input_exits_0_no_output(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing tool_input exits 0 and produces no stdout."""
+    payload = json.dumps({"tool_name": "Bash"})
+    _set_stdin(monkeypatch, payload)
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Output JSON shape
+# ---------------------------------------------------------------------------
+
+
+def test_output_hook_event_name_is_pretooluse(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """hookSpecificOutput.hookEventName is 'PreToolUse'."""
+    _set_stdin(monkeypatch, _bash_payload("pytest tests/"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+
+
+def test_reminder_text_contains_ctx_batch_execute(hook: types.ModuleType) -> None:
+    """REMINDER constant mentions ctx_batch_execute."""
+    assert "ctx_batch_execute" in hook.REMINDER
+
+
+def test_reminder_text_contains_ctx_search(hook: types.ModuleType) -> None:
+    """REMINDER constant mentions ctx_search."""
+    assert "ctx_search" in hook.REMINDER

--- a/tests/test_hook_precompact_checkpoint.py
+++ b/tests/test_hook_precompact_checkpoint.py
@@ -1,0 +1,272 @@
+"""Tests for the ``precompact-checkpoint`` PreCompact hook.
+
+The hook script lives at ``tools/hooks/ai/precompact-checkpoint.py``. Its filename
+contains hyphens, so it isn't directly importable — we load it via ``importlib`` and
+invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "precompact-checkpoint.py"
+)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("precompact_checkpoint", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["precompact_checkpoint"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("precompact_checkpoint", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _payload(cwd: str, transcript_path: str = "") -> str:
+    """Build a minimal PreCompact payload."""
+    return json.dumps({"cwd": cwd, "transcript_path": transcript_path})
+
+
+def _good_synthesis() -> dict[str, object]:
+    """Return a valid synthesis dict."""
+    return {
+        "title": "Add caching layer",
+        "status": "In progress — cache module drafted",
+        "in_flight_work": "Implementing LRU cache in src/cache.py",
+        "constraints": "Must be thread-safe",
+        "files_touched": ["src/cache.py", "tests/test_cache.py"],
+        "next_steps": "1. Write tests\n2. Run doit check",
+        "resume_prompt": "Continue implementing the cache module.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_writes_checkpoint(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Stub synthesizer returns valid JSON → markdown file written with correct sections."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(hook, "synthesize_checkpoint", lambda *_: _good_synthesis())
+    _set_stdin(monkeypatch, _payload(str(tmp_path), "transcript.jsonl"))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    text = checkpoints[0].read_text(encoding="utf-8")
+    assert "Add caching layer" in text
+    assert "In progress" in text
+    assert "src/cache.py" in text
+    assert "Continue implementing" in text
+
+
+def test_happy_path_filename_convention(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Written file must match ``{inv_epoch}-auto-precompact.md`` pattern."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(hook, "synthesize_checkpoint", lambda *_: _good_synthesis())
+    _set_stdin(monkeypatch, _payload(str(tmp_path), "t.jsonl"))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    name = checkpoints[0].name
+    # Name must be "{10-digit-prefix}-auto-precompact.md"
+    parts = name.split("-", 1)
+    assert len(parts) == 2
+    assert parts[0].isdigit() and len(parts[0]) == 10
+
+
+# ---------------------------------------------------------------------------
+# Fallback: synthesis returns None
+# ---------------------------------------------------------------------------
+
+
+def test_synthesis_none_writes_fallback(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Synthesizer returns None → fallback file written with AUTO_PARTIAL banner."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    transcript_file = tmp_path / "t.jsonl"
+    transcript_file.write_text("some transcript content", encoding="utf-8")
+    monkeypatch.setattr(hook, "synthesize_checkpoint", lambda *_: None)
+    _set_stdin(monkeypatch, _payload(str(tmp_path), str(transcript_file)))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    text = checkpoints[0].read_text(encoding="utf-8")
+    assert "AUTO_PARTIAL" in text
+
+
+# ---------------------------------------------------------------------------
+# Fallback: invalid JSON from synthesizer
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_synthesis_json_writes_fallback(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Real synthesize_checkpoint with JSON parse failure → fallback (mocked at subprocess)."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    transcript_file = tmp_path / "t.jsonl"
+    transcript_file.write_text("transcript", encoding="utf-8")
+
+    # Simulate synthesize_checkpoint returning None (as it would on JSONDecodeError).
+    monkeypatch.setattr(hook, "synthesize_checkpoint", lambda *_: None)
+    _set_stdin(monkeypatch, _payload(str(tmp_path), str(transcript_file)))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    assert "AUTO_PARTIAL" in checkpoints[0].read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Missing transcript path
+# ---------------------------------------------------------------------------
+
+
+def test_missing_transcript_writes_fallback(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Missing transcript file → fallback written; exits 0."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    # Provide a path that does not exist; synthesize_checkpoint not called.
+    _set_stdin(monkeypatch, _payload(str(tmp_path), str(tmp_path / "nonexistent.jsonl")))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    assert "AUTO_PARTIAL" in checkpoints[0].read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Malformed stdin JSON
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_stdin_is_noop(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Invalid JSON on stdin → exits 0, no file written."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    _set_stdin(monkeypatch, "not json at all")
+
+    assert hook.main() == 0
+
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    assert not checkpoints_dir.exists() or not list(checkpoints_dir.glob("*.md"))
+
+
+# ---------------------------------------------------------------------------
+# Subprocess raises TimeoutExpired
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_checkpoint_timeout_returns_none(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """synthesize_checkpoint swallows TimeoutExpired and returns None."""
+
+    def _raise_timeout(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise subprocess.TimeoutExpired(cmd="claude", timeout=90)
+
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+
+    result = hook.synthesize_checkpoint("some transcript")
+    assert result is None
+
+
+def test_timeout_in_main_writes_fallback(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """If synthesize_checkpoint raises (or returns None after timeout), fallback is written."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    transcript_file = tmp_path / "t.jsonl"
+    transcript_file.write_text("session transcript", encoding="utf-8")
+
+    monkeypatch.setattr(hook, "synthesize_checkpoint", lambda *_: None)
+    _set_stdin(monkeypatch, _payload(str(tmp_path), str(transcript_file)))
+
+    assert hook.main() == 0
+
+    checkpoints = list((tmp_path / "tmp" / "checkpoints").glob("*-auto-precompact*.md"))
+    assert len(checkpoints) == 1
+    assert "AUTO_PARTIAL" in checkpoints[0].read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# inv_epoch helper
+# ---------------------------------------------------------------------------
+
+
+def test_inv_epoch_is_10_digit_decreasing(
+    hook: types.ModuleType,
+) -> None:
+    """_inv_epoch() produces a 10-digit string that decreases over time."""
+    import time
+
+    e1 = hook._inv_epoch()
+    time.sleep(0.01)
+    e2 = hook._inv_epoch()
+
+    assert len(e1) == 10
+    assert e1.isdigit()
+    # e1 was computed first (earlier time → larger inv_epoch).
+    assert int(e1) >= int(e2)

--- a/tests/test_hook_session_resume_restore.py
+++ b/tests/test_hook_session_resume_restore.py
@@ -1,0 +1,245 @@
+"""Tests for the ``session-resume-restore`` SessionStart hook.
+
+The hook script lives at ``tools/hooks/ai/session-resume-restore.py``. Its filename
+contains hyphens, so it isn't directly importable — we load it via ``importlib`` and
+invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "session-resume-restore.py"
+)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("session_resume_restore", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["session_resume_restore"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("session_resume_restore", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _payload(cwd: str) -> str:
+    """Build a minimal SessionStart payload."""
+    return json.dumps({"cwd": cwd})
+
+
+def _make_checkpoint(checkpoints_dir: Path, name: str, body: str = "checkpoint body") -> Path:
+    """Create a checkpoint file under *checkpoints_dir* and return its path."""
+    checkpoints_dir.mkdir(parents=True, exist_ok=True)
+    p = checkpoints_dir / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Happy path: single auto-precompact checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_single_checkpoint_returned(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Single *-auto-precompact*.md → stdout JSON with additionalContext = file body."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    _make_checkpoint(checkpoints_dir, "9999999000-auto-precompact.md", "resume here")
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+    assert out["hookSpecificOutput"]["additionalContext"] == "resume here"
+
+
+# ---------------------------------------------------------------------------
+# Multiple checkpoints → lexically smallest (newest) selected
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_checkpoints_newest_selected(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Lexically smallest name (smallest inv_epoch → newest) is selected.
+
+    inv_epoch = 9999999999 - int(time.time()): it *decreases* as time advances.
+    A smaller inv_epoch means more time has passed → the file was created later → it is newer.
+    sorted() ascending picks the smallest inv_epoch first, which is the newest file.
+    """
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    # Larger inv_epoch = fewer seconds elapsed → created earlier → older.
+    _make_checkpoint(checkpoints_dir, "9999999000-auto-precompact.md", "older")
+    # Smaller inv_epoch = more seconds elapsed → created later → newer.
+    _make_checkpoint(checkpoints_dir, "9999998000-auto-precompact.md", "newer")
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["hookSpecificOutput"]["additionalContext"] == "newer"
+
+
+# ---------------------------------------------------------------------------
+# No checkpoint files → no-op
+# ---------------------------------------------------------------------------
+
+
+def test_no_checkpoints_is_noop(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No matching files → no stdout, exits 0."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    checkpoints_dir.mkdir(parents=True, exist_ok=True)
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# tmp/checkpoints/ doesn't exist → no-op
+# ---------------------------------------------------------------------------
+
+
+def test_missing_checkpoints_dir_is_noop(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing tmp/checkpoints/ directory → no-op, exits 0."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    # Do NOT create the directory.
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE_NO_AUTO_RESTORE=1 → no-op even when checkpoints exist
+# ---------------------------------------------------------------------------
+
+
+def test_no_auto_restore_env_skips(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLAUDE_NO_AUTO_RESTORE=1 → no-op even when a checkpoint exists."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_NO_AUTO_RESTORE", "1")
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    _make_checkpoint(checkpoints_dir, "9999999000-auto-precompact.md", "should not restore")
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# Manual /checkpoint files (no auto-precompact slug) ignored by default glob
+# ---------------------------------------------------------------------------
+
+
+def test_manual_checkpoint_ignored_by_default(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Manual checkpoint (no auto-precompact slug) is ignored by default glob."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.delenv("CLAUDE_RESTORE_ANY", raising=False)
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    _make_checkpoint(checkpoints_dir, "9999999000-my-manual-checkpoint.md", "manual")
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_restore_any_env_includes_manual_checkpoint(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLAUDE_RESTORE_ANY=1 widens the glob to include manual checkpoints."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_RESTORE_ANY", "1")
+    checkpoints_dir = tmp_path / "tmp" / "checkpoints"
+    _make_checkpoint(checkpoints_dir, "9999999000-my-manual-checkpoint.md", "manual body")
+    _set_stdin(monkeypatch, _payload(str(tmp_path)))
+
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["hookSpecificOutput"]["additionalContext"] == "manual body"
+
+
+# ---------------------------------------------------------------------------
+# Malformed stdin JSON → no-op
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_stdin_is_noop(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Invalid JSON on stdin → no-op, exits 0."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    _set_stdin(monkeypatch, "not valid json {{")
+
+    assert hook.main() == 0
+    assert capsys.readouterr().out == ""

--- a/tools/hooks/ai/bash-ban-raw-tools.py
+++ b/tools/hooks/ai/bash-ban-raw-tools.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+Claude Code PreToolUse hook to block raw shell commands when native tools are available.
+
+This hook intercepts Bash commands before execution and blocks those that AI agents
+should be using native file tools for instead (Read, Grep, Glob, Edit, Write).
+
+Blocks:
+  - Leading banned commands: cat, head, tail, find, grep, rg, wc
+
+Escape hatch:
+  Touch <project>/tmp/agents/claude/bash-raw-unlock (where <project> is resolved
+  from the CLAUDE_PROJECT_DIR env var or the cwd field in the hook's stdin payload)
+  to allow banned commands for 10 minutes. The file auto-expires — no cleanup needed.
+  The unlock file is scoped to the project so one project's unlock does not affect
+  any other project running concurrently.
+
+Exit codes:
+  0 - Allow command
+  1 - Malformed JSON input
+  2 - Block command (shows stderr to Claude)
+
+This hook is Claude-only (reads {"tool_name": "Bash", "tool_input": {"command": "..."}}).
+For always-on dangerous-command blocking, see: tools/hooks/ai/block-dangerous-commands.py
+For documentation, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+import json
+import os
+import shlex
+import sys
+import time
+from pathlib import Path
+
+# Commands that AI agents should never use via Bash when native tools are available
+BANNED_COMMANDS: frozenset[str] = frozenset({"cat", "head", "tail", "find", "grep", "rg", "wc"})
+
+# Relative path (from project root) of the per-project escape-hatch file
+UNLOCK_FILE_RELATIVE: str = "tmp/agents/claude/bash-raw-unlock"
+
+# How long the escape hatch stays valid after the file is touched (seconds)
+UNLOCK_WINDOW_SECONDS: int = 600
+
+# Native tool suggestions for each banned command
+_SUGGESTIONS: dict[str, str] = {
+    "cat": "Read",
+    "head": "Read",
+    "tail": "Read",
+    "find": "Glob",
+    "grep": "Grep",
+    "rg": "Grep",
+    "wc": "Read (then count lines/words in the result)",
+}
+
+
+def tokenize(command: str) -> list[str]:
+    """
+    Tokenize command using shlex for proper shell quote handling.
+
+    Returns list of tokens with quotes stripped from values.
+    Falls back to non-POSIX mode, then simple whitespace split on malformed input.
+    """
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        try:
+            return shlex.split(command, posix=False)
+        except ValueError:
+            return command.split()
+
+
+def _resolve_unlock_path(input_data: dict[str, object]) -> Path | None:
+    """
+    Resolve the per-project unlock file path.
+
+    Reads CLAUDE_PROJECT_DIR env var first; falls back to the ``cwd`` field in
+    *input_data*.  Returns ``None`` when neither is available (project root
+    cannot be determined).
+    """
+    project_dir: str = os.environ.get("CLAUDE_PROJECT_DIR", "") or str(input_data.get("cwd", ""))
+    if not project_dir:
+        return None
+    return Path(project_dir) / UNLOCK_FILE_RELATIVE
+
+
+def is_unlocked(unlock_path: Path | None) -> bool:
+    """Return True iff *unlock_path* exists and was modified within UNLOCK_WINDOW_SECONDS."""
+    if unlock_path is None:
+        return False
+    try:
+        mtime = unlock_path.stat().st_mtime
+        return (time.time() - mtime) <= UNLOCK_WINDOW_SECONDS
+    except OSError:
+        return False
+
+
+def find_banned_leading(tokens: list[str]) -> str | None:
+    """Return the first token if it is in BANNED_COMMANDS, else None."""
+    if tokens and tokens[0] in BANNED_COMMANDS:
+        return tokens[0]
+    return None
+
+
+def _build_reason(offending: str, unlock_path: Path | None) -> str:
+    """Build a human-readable block reason for the given offending command."""
+    suggestion = _SUGGESTIONS.get(offending, "a native tool")
+    if unlock_path is not None:
+        hatch_line = (
+            f"Escape hatch: `touch {unlock_path}` (run from any shell) to allow "
+            f"raw commands for {UNLOCK_WINDOW_SECONDS // 60} minutes. "
+            f"The unlock is scoped to this project."
+        )
+    else:
+        hatch_line = (
+            "Escape hatch unavailable: project root could not be determined "
+            "(CLAUDE_PROJECT_DIR is unset and no cwd was provided). "
+            "Set CLAUDE_PROJECT_DIR to the project root to enable the escape hatch."
+        )
+    return (
+        f"Blocked: `{offending}` is a raw shell command.\n"
+        f"Use the native `{suggestion}` tool instead — it produces a better result "
+        f"with fewer tokens.\n"
+        f"{hatch_line}"
+    )
+
+
+def main() -> int:
+    """Main entry point."""
+    try:
+        input_data: dict[str, object] = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"Invalid JSON input: {e}", file=sys.stderr)
+        return 1
+
+    # This hook is Claude-only: expects {"tool_name": ..., "tool_input": {...}}
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        return 0
+
+    tool_input = input_data.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command", "")
+    if not isinstance(command, str) or not command:
+        return 0
+
+    unlock_path = _resolve_unlock_path(input_data)
+
+    # Escape hatch: allow if unlock file is fresh
+    if is_unlocked(unlock_path):
+        return 0
+
+    tokens = tokenize(command)
+
+    # Check for banned leading command
+    offending = find_banned_leading(tokens)
+    if offending is not None:
+        print(_build_reason(offending, unlock_path), file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -2,8 +2,9 @@
 """
 Claude Code PreToolUse hook to block dangerous command patterns.
 
-This hook intercepts Bash commands before execution and blocks those
-containing dangerous flags that could bypass security controls.
+This hook intercepts Bash commands and file-edit operations before execution
+and blocks those containing dangerous flags or attempting to persist the
+ALLOW_AI_READY_TO_MERGE env var to shell configuration files.
 
 Uses shlex to properly parse shell quoting, then checks for dangerous
 patterns as standalone tokens (not embedded in quoted argument values).
@@ -63,9 +64,89 @@ BLOCKED_WORKFLOW_COMMANDS = {
 GOVERNANCE_LABELS = {
     "ready-to-merge": (
         "The 'ready-to-merge' label is a governance control requiring human approval. "
-        "Add this label manually via 'gh pr edit --add-label ready-to-merge' or the GitHub web UI."
+        "Add this label manually via 'gh pr edit --add-label ready-to-merge' or the GitHub web UI, "
+        "or set ALLOW_AI_READY_TO_MERGE=1 in the shell before launching the AI CLI."
     ),
 }
+
+# Env var name the human can set to allow AI to apply ready-to-merge
+ALLOW_AI_READY_TO_MERGE_VAR = "ALLOW_AI_READY_TO_MERGE"
+
+# Persistence-protected file basenames and path hints.
+# Keys are basenames; values are optional required parent path fragments
+# (if non-empty, the parent directory must contain that fragment).
+ENV_PERSISTENCE_TARGETS: dict[str, str] = {
+    ".bashrc": "",
+    ".zshrc": "",
+    ".profile": "",
+    ".bash_profile": "",
+    ".bash_login": "",
+    ".zshenv": "",
+    "config.fish": ".config/fish",
+    ".envrc": "",
+    ".env": "",
+    ".env.local": "",
+    ".env.development": "",
+    ".env.production": "",
+    "copilot-hooks.json": "",
+}
+
+# Settings files that are only protected when inside a known AI CLI config dir
+_AI_CLI_SETTINGS_TARGETS: dict[str, set[str]] = {
+    "settings.json": {".claude", ".gemini", ".copilot"},
+    "settings.local.json": {".claude", ".gemini", ".copilot"},
+    "config.toml": {".codex"},
+}
+
+
+def _env_truthy(name: str) -> bool:
+    """Return True when env var *name* is set to a truthy value.
+
+    Truthy values (case-insensitive): ``1``, ``true``, ``yes``, ``on``.
+    All other values (including empty string) are falsy.
+    """
+    val = os.environ.get(name, "").strip().lower()
+    return val in {"1", "true", "yes", "on"}
+
+
+def _is_env_persistence_target(path_str: str) -> bool:
+    """Return True when *path_str* points to a file that the AI must not use
+    to persist the ``ALLOW_AI_READY_TO_MERGE`` env var.
+
+    Checks:
+    - Basename + optional parent-path fragment (ENV_PERSISTENCE_TARGETS)
+    - AI CLI settings files only when the immediate parent dir is in the
+      corresponding allow-list (_AI_CLI_SETTINGS_TARGETS)
+    """
+    if not path_str:
+        return False
+
+    try:
+        # Expand ~ so ~/.bashrc comparisons work
+        path = Path(path_str).expanduser()
+    except (ValueError, RuntimeError):
+        return False
+
+    basename = path.name
+    parent = path.parent
+
+    # Check plain persistence targets
+    if basename in ENV_PERSISTENCE_TARGETS:
+        fragment = ENV_PERSISTENCE_TARGETS[basename]
+        if not fragment:
+            return True
+        # Fragment must appear in the parent path string
+        parent_posix = parent.as_posix()
+        if fragment in parent_posix:
+            return True
+
+    # Check AI CLI settings files
+    if basename in _AI_CLI_SETTINGS_TARGETS:
+        allowed_parents = _AI_CLI_SETTINGS_TARGETS[basename]
+        if parent.name in allowed_parents:
+            return True
+
+    return False
 
 
 def tokenize(command: str) -> list[str]:
@@ -290,7 +371,7 @@ def check_governance_labels(tokens: list[str]) -> tuple[bool, str]:
     Check if command attempts to add a governance label.
 
     Governance labels (like 'ready-to-merge') require human approval and
-    should never be added by AI agents.
+    should never be added by AI agents unless ALLOW_AI_READY_TO_MERGE is set.
     """
     tokens_lower = [t.lower() for t in tokens]
 
@@ -308,7 +389,187 @@ def check_governance_labels(tokens: list[str]) -> tuple[bool, str]:
     # Check if any governance label is being added
     for label, reason in GOVERNANCE_LABELS.items():
         if label.lower() in tokens_lower:
+            # Allow bypass when the human has explicitly set the env var
+            if label == "ready-to-merge" and _env_truthy(ALLOW_AI_READY_TO_MERGE_VAR):
+                return False, ""
             return True, reason
+
+    return False, ""
+
+
+# Shell write operators (as standalone tokens after shlex.split)
+_WRITE_REDIRECTS = {">", ">>"}
+
+# Shell commands that write to a file argument
+_WRITE_COMMANDS = {"tee", "cp", "mv", "dd"}
+
+# Script interpreters that can write files via -c/-e/--command
+_INTERPRETER_COMMANDS = {"python", "python3", "perl", "ruby", "node"}
+
+# Subshell separators used to bound a single command segment
+_COMMAND_SEPARATORS = {"&&", "||", ";", "|"}
+
+
+def _bash_writes_to_persistence_target(tokens: list[str]) -> bool:
+    """Return True if the token stream contains a write operation targeting a
+    persistence-protected file.
+
+    Detected patterns:
+    - A:  ``>`` / ``>>`` standalone token followed by a persistence target
+    - B:  ``>foo`` / ``>>foo`` no-space form where ``foo`` is a persistence target
+    - C:  ``tee`` / ``cp`` / ``mv`` / ``dd`` with a persistence target as a
+          positional argument before the next command separator
+    - D:  ``sed -i`` (in-place edit) with a persistence target as a positional
+    - E:  script interpreter (``python``/``python3``/``perl``/``ruby``/``node``)
+          invoked with ``-c`` / ``-e`` / ``--command`` whose script body mentions
+          any persistence-target basename
+    """
+    n = len(tokens)
+    for i, tok in enumerate(tokens):
+        # Pattern A: standalone redirect operator
+        if tok in _WRITE_REDIRECTS:
+            if i + 1 < n and _is_env_persistence_target(tokens[i + 1]):
+                return True
+            continue
+
+        # Pattern B: redirect operator concatenated with target (no whitespace)
+        if tok.startswith(">>") and len(tok) > 2:
+            if _is_env_persistence_target(tok[2:]):
+                return True
+            continue
+        if tok.startswith(">") and len(tok) > 1 and tok[1] not in {"=", ">"}:
+            # Skip ">=" (comparison) and ">>" (already handled)
+            if _is_env_persistence_target(tok[1:]):
+                return True
+            continue
+
+        # Pattern C: write command followed by persistence target as positional
+        if tok in _WRITE_COMMANDS:
+            for j in range(i + 1, n):
+                t = tokens[j]
+                if t in _COMMAND_SEPARATORS:
+                    break
+                if t.startswith("-"):
+                    continue
+                if _is_env_persistence_target(t):
+                    return True
+            continue
+
+        # Pattern D: sed -i (in-place) with persistence target
+        if tok == "sed":
+            has_in_place = False
+            for j in range(i + 1, n):
+                t = tokens[j]
+                if t in _COMMAND_SEPARATORS:
+                    break
+                if t.startswith("-i"):
+                    has_in_place = True
+                    continue
+                if not has_in_place:
+                    continue
+                if t.startswith("-"):
+                    continue
+                if _is_env_persistence_target(t):
+                    return True
+            continue
+
+        # Pattern E: script interpreter with -c/-e/--command and target in body
+        if tok in _INTERPRETER_COMMANDS:
+            cmd_end = n
+            for j in range(i + 1, n):
+                if tokens[j] in _COMMAND_SEPARATORS:
+                    cmd_end = j
+                    break
+            segment = tokens[i + 1 : cmd_end]
+            has_inline = any(
+                t in {"-c", "-e", "--command"} or t.startswith(("-c=", "-e=", "--command="))
+                for t in segment
+            )
+            if not has_inline:
+                continue
+            persistence_basenames = set(ENV_PERSISTENCE_TARGETS) | set(_AI_CLI_SETTINGS_TARGETS)
+            for t in segment:
+                for basename in persistence_basenames:
+                    if basename in t:
+                        return True
+            continue
+
+    return False
+
+
+def check_env_persistence_in_bash(tokens: list[str]) -> tuple[bool, str]:
+    """Block Bash commands that would persist ALLOW_AI_READY_TO_MERGE to a
+    protected file.
+
+    Two conditions must both hold:
+    - The literal string ``ALLOW_AI_READY_TO_MERGE`` appears in any token, AND
+    - The command performs a write operation targeting a persistence-protected
+      file (see :func:`_bash_writes_to_persistence_target` for patterns).
+
+    Plain mention of the var name (e.g., in a commit message, a doc string, or
+    `git add` arguments that reference protected file paths) is NOT a write
+    operation and is allowed.
+    """
+    var_name = ALLOW_AI_READY_TO_MERGE_VAR
+    if not any(var_name in t for t in tokens):
+        return False, ""
+    if not _bash_writes_to_persistence_target(tokens):
+        return False, ""
+    return True, (
+        f"Blocked: AI must not persist {var_name} to shell or project config files. "
+        f"Only a human can set this variable in their environment."
+    )
+
+
+def check_env_persistence_in_file_edit(
+    tool_name: str, tool_input: dict[str, object]
+) -> tuple[bool, str]:
+    """Block file-edit operations (Edit/Write/MultiEdit for Claude/Codex,
+    write_file/replace for Gemini) that would persist ALLOW_AI_READY_TO_MERGE
+    to a protected file.
+
+    Triggers when:
+    - The target file_path is a persistence-protected target, AND
+    - The new content being written contains ALLOW_AI_READY_TO_MERGE.
+    """
+    var_name = ALLOW_AI_READY_TO_MERGE_VAR
+
+    file_path_raw = str(tool_input.get("file_path", "") or "")
+    if not file_path_raw:
+        return False, ""
+
+    if not _is_env_persistence_target(file_path_raw):
+        return False, ""
+
+    # Collect all new content being written
+    new_content_parts: list[str] = []
+
+    tool_lower = tool_name.lower()
+
+    if tool_lower in ("write", "write_file"):
+        # Write/write_file: full file content in 'content' key
+        content = str(tool_input.get("content", "") or "")
+        new_content_parts.append(content)
+
+    elif tool_lower in ("edit", "replace"):
+        # Edit (Claude/Codex) and replace (Gemini): new_string key
+        new_content_parts.append(str(tool_input.get("new_string", "") or ""))
+
+    elif tool_lower == "multiedit":
+        # MultiEdit: edits is a list of {old_string, new_string} dicts
+        edits = tool_input.get("edits", [])
+        if isinstance(edits, list):
+            for edit_item in edits:
+                if isinstance(edit_item, dict):
+                    new_content_parts.append(str(edit_item.get("new_string", "") or ""))
+
+    # Check if any new content contains the env var name
+    combined = "\n".join(new_content_parts)
+    if var_name in combined:
+        return True, (
+            f"Blocked: AI must not persist {var_name} to '{file_path_raw}'. "
+            f"Only a human can set this variable in their environment."
+        )
 
     return False, ""
 
@@ -394,36 +655,44 @@ def check_command(command: str) -> tuple[bool, str]:
     if is_dangerous:
         return True, reason
 
+    # Check for attempts to persist ALLOW_AI_READY_TO_MERGE via Bash
+    is_dangerous, reason = check_env_persistence_in_bash(tokens)
+    if is_dangerous:
+        return True, reason
+
     return False, ""
 
 
-def _parse_input(input_data: dict) -> tuple[str, str]:
+def _parse_input(input_data: dict) -> tuple[str, str, dict]:
     """
-    Parse tool name and command from hook input.
+    Parse tool name, command, and tool_input from hook input.
 
     Handles two input formats:
     - Claude/Gemini: {"tool_name": "Bash", "tool_input": {"command": "..."}}
     - Copilot CLI:   {"toolName": "bash", "toolArgs": "{\"command\":\"...\"}"}
 
     Returns:
-        (tool_name, command) tuple
+        (tool_name, command, tool_input) tuple where tool_input is the full
+        parameter dict (used for file-edit operations).
     """
     # Copilot CLI format uses camelCase keys
     if "toolName" in input_data:
         tool_name = input_data.get("toolName", "")
         tool_args_raw = input_data.get("toolArgs", "{}")
         try:
-            tool_args = (
+            tool_input: dict = (
                 json.loads(tool_args_raw) if isinstance(tool_args_raw, str) else tool_args_raw
             )
         except json.JSONDecodeError:
-            tool_args = {}
-        return tool_name, tool_args.get("command", "")
+            tool_input = {}
+        return tool_name, tool_input.get("command", ""), tool_input
 
     # Claude/Gemini format uses snake_case keys
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
-    return tool_name, tool_input.get("command", "")
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+    return tool_name, tool_input.get("command", ""), tool_input
 
 
 def _is_copilot_format(input_data: dict) -> bool:
@@ -445,6 +714,41 @@ def _log(entry: dict) -> None:
         pass  # Never fail due to logging
 
 
+_BASH_TOOL_NAMES = frozenset({"Bash", "run_shell_command", "bash"})
+
+# File-edit tool names across all supported AI CLIs
+# Claude/Codex: Edit, Write, MultiEdit
+# Gemini: write_file, replace
+_FILE_EDIT_TOOL_NAMES = frozenset({"Edit", "Write", "MultiEdit", "write_file", "replace"})
+
+
+def _block_response(copilot_format: bool, reason: str, command: str) -> int:
+    """Emit a block response and return the appropriate exit code."""
+    if copilot_format:
+        # Copilot CLI: deny via JSON output to stdout
+        output = json.dumps(
+            {
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    f"Blocked: {reason}. If intentional, ask the user to run it manually."
+                ),
+            }
+        )
+        print(output)
+        return 0
+    else:
+        # Claude/Gemini: block via exit code 2 + stderr message
+        print(
+            f"BLOCKED: Operation contains dangerous pattern.\n"
+            f"Reason: {reason}\n"
+            f"Operation: {command}\n"
+            f"\n"
+            f"If this is intentional, ask the user to run it manually.",
+            file=sys.stderr,
+        )
+        return 2  # Exit 2 = Block and show stderr to Claude/Gemini
+
+
 def main() -> int:
     """Main entry point."""
     try:
@@ -453,7 +757,7 @@ def main() -> int:
         print(f"Invalid JSON input: {e}", file=sys.stderr)
         return 1
 
-    tool_name, command = _parse_input(input_data)
+    tool_name, command, tool_input = _parse_input(input_data)
     copilot_format = _is_copilot_format(input_data)
 
     _log(
@@ -465,41 +769,22 @@ def main() -> int:
         }
     )
 
-    # Only check shell commands:
-    # - "Bash" for Claude
-    # - "run_shell_command" for Gemini
-    # - "bash" for Copilot CLI
-    if tool_name not in ("Bash", "run_shell_command", "bash"):
-        return 0
-
-    if not command:
-        return 0
-
-    is_dangerous, reason = check_command(command)
-    if is_dangerous:
-        if copilot_format:
-            # Copilot CLI: deny via JSON output to stdout
-            output = json.dumps(
-                {
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": (
-                        f"Blocked: {reason}. If intentional, ask the user to run it manually."
-                    ),
-                }
-            )
-            print(output)
+    # --- Bash / shell command path ---
+    if tool_name in _BASH_TOOL_NAMES:
+        if not command:
             return 0
-        else:
-            # Claude/Gemini: block via exit code 2 + stderr message
-            print(
-                f"BLOCKED: Command contains dangerous pattern.\n"
-                f"Reason: {reason}\n"
-                f"Command: {command}\n"
-                f"\n"
-                f"If this is intentional, ask the user to run it manually.",
-                file=sys.stderr,
-            )
-            return 2  # Exit 2 = Block and show stderr to Claude/Gemini
+        is_dangerous, reason = check_command(command)
+        if is_dangerous:
+            return _block_response(copilot_format, reason, command)
+        return 0
+
+    # --- File-edit tool path (Edit/Write/MultiEdit/write_file/replace) ---
+    if tool_name in _FILE_EDIT_TOOL_NAMES:
+        is_dangerous, reason = check_env_persistence_in_file_edit(tool_name, tool_input)
+        if is_dangerous:
+            file_path = str(tool_input.get("file_path", ""))
+            return _block_response(copilot_format, reason, f"{tool_name} {file_path}")
+        return 0
 
     return 0
 

--- a/tools/hooks/ai/cbm-code-discovery-gate.py
+++ b/tools/hooks/ai/cbm-code-discovery-gate.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Claude Code PreToolUse hook to gate code-discovery tools behind a CBM (Codebase Memory MCP) call.
+
+This hook intercepts Read, Grep, and Glob calls before execution and blocks those targeting
+source-code files unless a CBM tool has been called recently (within MARKER_TTL_SECONDS) or
+the path matches the allow-list (configs, docs, tests, hooks, settings).
+
+The gate exists to encourage agents to query the CBM knowledge graph first — which answers
+structural queries for far fewer tokens than reading files directly — and only fall back to
+raw file reads for targets that CBM cannot help with (config, docs, test files).
+
+Allow-list:
+  File extensions: .json .yaml .yml .md .toml .lock .txt .env .sh
+  Path fragments:  .claude/ CLAUDE.md settings hooks/ tests/ _test.
+
+Escape hatch:
+  CBM marker: any call to a CBM MCP tool (matched by the PostToolUse marker hook) touches
+  MARKER_FILE_TEMPLATE, opening a MARKER_TTL_SECONDS window during which Read/Grep/Glob
+  on source files is allowed.
+
+Exit codes:
+  0 - Allow (allow-list match, marker fresh, or non-gated tool)
+  1 - Malformed JSON input
+  2 - Block (source file + no fresh marker; shows stderr to Claude)
+
+This hook is Claude-only (reads {"tool_name": ..., "tool_input": {...}}).
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+# Tool names this gate applies to (the matcher does the first cut, but defensively re-check).
+GATED_TOOLS: frozenset[str] = frozenset({"Read", "Grep", "Glob"})
+
+# Files / paths that always pass through (configs, docs, tests, project metadata).
+# Source-code files (.py, .js, .ts, .go, etc.) are NOT in the allow-list and require
+# a recent CBM call.
+ALLOWLIST_REGEX: re.Pattern[str] = re.compile(
+    r"\.(json|yaml|yml|md|toml|lock|txt|env|sh)$"
+    r"|\.claude/|CLAUDE\.md|settings|hooks/|(^|/)tests?/|_test\."
+)
+
+# Marker file template. {ppid} interpolates to os.getppid() at runtime so the
+# marker is scoped per-Claude-Code-session.
+MARKER_FILE_TEMPLATE: str = "/tmp/cbm-mcp-used-{ppid}"  # nosec B108 - well-known path is intentional; operators must be able to touch it from any shell. Configurable via this constant.
+
+# How long the marker stays valid after the last CBM tool call (seconds).
+MARKER_TTL_SECONDS: int = 120
+
+
+def _marker_fresh() -> bool:
+    """Return True iff the CBM marker file exists and was modified within MARKER_TTL_SECONDS."""
+    path = Path(MARKER_FILE_TEMPLATE.format(ppid=os.getppid()))
+    try:
+        mtime = path.stat().st_mtime
+        return (time.time() - mtime) <= MARKER_TTL_SECONDS
+    except OSError:
+        return False
+
+
+def _build_block_reason(tool_name: str, path_value: str) -> str:
+    """Build a human-readable block reason naming the gated tool and recovery steps."""
+    marker_path = MARKER_FILE_TEMPLATE.format(ppid=os.getppid())
+    target_desc = f"`{path_value}`" if path_value else "a whole-repo search"
+    return (
+        f"Blocked: `{tool_name}` on {target_desc} requires a recent CBM call.\n"
+        f"Call `mcp__codebase-memory__search_graph` (or another CBM tool) first, "
+        f"then retry within {MARKER_TTL_SECONDS}s.\n"
+        f"CBM marker: {marker_path}\n"
+        f"Allow-list bypass: configs, docs, tests, and settings files are always allowed."
+    )
+
+
+def main() -> int:
+    """Main entry point."""
+    try:
+        input_data: dict[str, object] = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"Invalid JSON input: {e}", file=sys.stderr)
+        return 1
+
+    # Defensive check: this hook is Claude-only and expects a specific payload shape.
+    tool_name = input_data.get("tool_name", "")
+    if not isinstance(tool_name, str) or tool_name not in GATED_TOOLS:
+        return 0
+
+    tool_input = input_data.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        return 0
+
+    # Extract the path argument. Read uses "file_path"; Grep/Glob use "path".
+    # If path is absent (whole-repo Grep/Glob), path_value is "" — NOT auto-allowed.
+    if tool_name == "Read":
+        path_value = tool_input.get("file_path", "")
+    else:
+        path_value = tool_input.get("path", "")
+
+    if not isinstance(path_value, str):
+        path_value = ""
+
+    # Allow-list: configs, docs, tests, hooks, settings always pass through.
+    if path_value and ALLOWLIST_REGEX.search(path_value):
+        return 0
+
+    # CBM escape hatch: marker file exists and is fresh (written by cbm-mcp-marker.py).
+    if _marker_fresh():
+        return 0
+
+    # Block: source file (or whole-repo search) without a fresh CBM call.
+    print(_build_block_reason(tool_name, path_value), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/cbm-mcp-marker.py
+++ b/tools/hooks/ai/cbm-mcp-marker.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Claude Code PostToolUse hook that touches a sidecar marker file whenever a CBM MCP tool fires.
+
+The marker file is used by the cbm-code-discovery-gate.py PreToolUse hook to open a
+MARKER_TTL_SECONDS (120s) window during which Read/Grep/Glob on source files is allowed
+without an additional CBM call.
+
+This hook is intentionally tool-name-agnostic: the ``matcher`` in settings.local.json
+(e.g., ``mcp__codebase-memory__.*``) determines which PostToolUse events reach this hook.
+Operators with non-default CBM server names tune the matcher, not this file.
+
+Exit codes:
+  0 - Always (best-effort; never blocks a tool call)
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Marker file template. {ppid} interpolates to os.getppid() at runtime so the
+# marker is scoped per-Claude-Code-session. Must match the constant in
+# cbm-code-discovery-gate.py.
+MARKER_FILE_TEMPLATE: str = "/tmp/cbm-mcp-used-{ppid}"  # nosec B108 - well-known path is intentional; operators must be able to touch it from any shell. Configurable via this constant.
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; never blocks. Tests call this directly."""
+    try:
+        try:
+            json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0  # Malformed JSON — best-effort, don't block.
+
+        marker = Path(MARKER_FILE_TEMPLATE.format(ppid=os.getppid()))
+        marker.touch()
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/cbm-session-reminder.md
+++ b/tools/hooks/ai/cbm-session-reminder.md
@@ -1,0 +1,44 @@
+# CBM Gate Protocol Reminder
+
+The **Codebase Memory MCP gate** is active for `Read`, `Grep`, and `Glob` on source files.
+
+## What the gate does
+
+Any `Read`/`Grep`/`Glob` call targeting a **source-code file** (`.py`, `.ts`, `.js`, `.go`, etc.)
+is blocked unless a CBM tool has been called within the last 120 seconds. This enforces the
+token-efficient query path: CBM's knowledge graph answers structural questions for far fewer tokens
+than reading files directly.
+
+## What always passes through (no CBM needed)
+
+The allow-list bypasses the gate automatically — you can read these directly:
+
+- Config files: `.json`, `.yaml`, `.yml`, `.toml`, `.lock`, `.txt`, `.env`, `.sh`
+- Docs: `.md`
+- Paths containing `.claude/`, `CLAUDE.md`, `settings`, `hooks/`, `tests/`, or `_test.`
+
+## How to work with the gate
+
+**Before querying source code, call a CBM tool first:**
+
+| Goal | CBM tool to call |
+| :--- | :--- |
+| Find where a function is defined | `mcp__codebase-memory__search_graph` |
+| Understand a module's structure | `mcp__codebase-memory__get_architecture` |
+| Trace a call path | `mcp__codebase-memory__trace_path` |
+| Read a specific function body | `mcp__codebase-memory__get_code_snippet` |
+| Ensure graph is current | `mcp__codebase-memory__index_repository` |
+
+After any CBM tool call, you have **120 seconds** to `Read`/`Grep`/`Glob` source files freely.
+
+## Whole-repo searches
+
+A `Grep` or `Glob` call with **no `path` argument** is always gated — it is exactly the case CBM
+is optimised for. Use `mcp__codebase-memory__search_graph` instead.
+
+## Keeping the graph current
+
+If the codebase has changed materially since the last index (new files, major refactors), call
+`mcp__codebase-memory__index_repository` to refresh. The gate remains active but the graph will
+give accurate results. Use `mcp__codebase-memory__detect_changes` to check whether a refresh is
+needed before indexing.

--- a/tools/hooks/ai/cbm-session-reminder.py
+++ b/tools/hooks/ai/cbm-session-reminder.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Claude Code SessionStart hook that re-injects the CBM gate protocol reminder.
+
+Triggered when Claude Code starts a session whose trigger contains "compact", "resume",
+or "clear" (configured via the matcher in ``.claude/settings.local.json``). Reads
+``cbm-session-reminder.md`` (a sibling file) and injects its contents into the new
+session via ``hookSpecificOutput.additionalContext``.
+
+This re-injection ensures that CBM gate conventions stay active throughout a session
+regardless of how many autocompact events have occurred. Without it, the model may
+honour the CBM protocol at session start but drift to raw Read/Grep/Glob late in a
+long session once the context has been compacted.
+
+The hook is best-effort: any failure (missing reminder file, malformed stdin) is
+swallowed and the hook exits 0 so it never blocks session startup.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Path to the reminder text. Sibling to the hook so it is portable.
+REMINDER_TEXT_PATH: Path = Path(__file__).resolve().parent / "cbm-session-reminder.md"
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; tests call this directly."""
+    try:
+        try:
+            json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0  # Malformed JSON — best-effort, don't block.
+
+        try:
+            body = REMINDER_TEXT_PATH.read_text(encoding="utf-8")
+        except (OSError, PermissionError):
+            return 0  # Missing or unreadable reminder file — degrade gracefully.
+
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": body,
+            }
+        }
+        sys.stdout.write(json.dumps(output))
+        sys.stdout.flush()
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/context-mode-posttooluse.py
+++ b/tools/hooks/ai/context-mode-posttooluse.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Claude Code PostToolUse wrapper for the context-mode MCP CLI.
+
+Forwards stdin to ``context-mode hook claude-code PostToolUse`` and re-emits
+stdout/stderr/exit-code. If the ``context-mode`` CLI is not installed, exits 0
+silently — non-installation is a no-op, not an error.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import subprocess  # nosec B404 - required to invoke context-mode CLI
+import sys
+
+EVENT_NAME = "PostToolUse"
+CLI_NAME = "context-mode"
+
+
+def main() -> int:
+    """Hook entry point. Forwards stdin to context-mode CLI or exits 0."""
+    try:
+        if shutil.which(CLI_NAME) is None:
+            with contextlib.suppress(Exception):
+                sys.stdin.buffer.read()  # drain stdin
+            return 0
+
+        try:
+            raw = sys.stdin.buffer.read()
+        except Exception:  # nosec B110
+            return 0
+
+        try:
+            result = subprocess.run(  # nosec B603 B607 - shutil.which guard validates path
+                [CLI_NAME, "hook", "claude-code", EVENT_NAME],
+                input=raw,
+                capture_output=True,
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return 0
+
+        with contextlib.suppress(Exception):
+            sys.stdout.buffer.write(result.stdout)
+            sys.stdout.buffer.flush()
+        with contextlib.suppress(Exception):
+            sys.stderr.buffer.write(result.stderr)
+            sys.stderr.buffer.flush()
+        return result.returncode
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/context-mode-precompact.py
+++ b/tools/hooks/ai/context-mode-precompact.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Claude Code PreCompact wrapper for the context-mode MCP CLI.
+
+Forwards stdin to ``context-mode hook claude-code PreCompact`` and re-emits
+stdout/stderr/exit-code. If the ``context-mode`` CLI is not installed, exits 0
+silently — non-installation is a no-op, not an error.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import subprocess  # nosec B404 - required to invoke context-mode CLI
+import sys
+
+EVENT_NAME = "PreCompact"
+CLI_NAME = "context-mode"
+
+
+def main() -> int:
+    """Hook entry point. Forwards stdin to context-mode CLI or exits 0."""
+    try:
+        if shutil.which(CLI_NAME) is None:
+            with contextlib.suppress(Exception):
+                sys.stdin.buffer.read()  # drain stdin
+            return 0
+
+        try:
+            raw = sys.stdin.buffer.read()
+        except Exception:  # nosec B110
+            return 0
+
+        try:
+            result = subprocess.run(  # nosec B603 B607 - shutil.which guard validates path
+                [CLI_NAME, "hook", "claude-code", EVENT_NAME],
+                input=raw,
+                capture_output=True,
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return 0
+
+        with contextlib.suppress(Exception):
+            sys.stdout.buffer.write(result.stdout)
+            sys.stdout.buffer.flush()
+        with contextlib.suppress(Exception):
+            sys.stderr.buffer.write(result.stderr)
+            sys.stderr.buffer.flush()
+        return result.returncode
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/context-mode-pretooluse.py
+++ b/tools/hooks/ai/context-mode-pretooluse.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse wrapper for the context-mode MCP CLI.
+
+Forwards stdin to ``context-mode hook claude-code PreToolUse`` and re-emits
+stdout/stderr/exit-code. If the ``context-mode`` CLI is not installed, exits 0
+silently — non-installation is a no-op, not an error.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import subprocess  # nosec B404 - required to invoke context-mode CLI
+import sys
+
+EVENT_NAME = "PreToolUse"
+CLI_NAME = "context-mode"
+
+
+def main() -> int:
+    """Hook entry point. Forwards stdin to context-mode CLI or exits 0."""
+    try:
+        if shutil.which(CLI_NAME) is None:
+            with contextlib.suppress(Exception):
+                sys.stdin.buffer.read()  # drain stdin
+            return 0
+
+        try:
+            raw = sys.stdin.buffer.read()
+        except Exception:  # nosec B110
+            return 0
+
+        try:
+            result = subprocess.run(  # nosec B603 B607 - shutil.which guard validates path
+                [CLI_NAME, "hook", "claude-code", EVENT_NAME],
+                input=raw,
+                capture_output=True,
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return 0
+
+        with contextlib.suppress(Exception):
+            sys.stdout.buffer.write(result.stdout)
+            sys.stdout.buffer.flush()
+        with contextlib.suppress(Exception):
+            sys.stderr.buffer.write(result.stderr)
+            sys.stderr.buffer.flush()
+        return result.returncode
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/context-mode-sessionstart.py
+++ b/tools/hooks/ai/context-mode-sessionstart.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Claude Code SessionStart wrapper for the context-mode MCP CLI.
+
+Forwards stdin to ``context-mode hook claude-code SessionStart`` and re-emits
+stdout/stderr/exit-code. If the ``context-mode`` CLI is not installed, exits 0
+silently — non-installation is a no-op, not an error.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import subprocess  # nosec B404 - required to invoke context-mode CLI
+import sys
+
+EVENT_NAME = "SessionStart"
+CLI_NAME = "context-mode"
+
+
+def main() -> int:
+    """Hook entry point. Forwards stdin to context-mode CLI or exits 0."""
+    try:
+        if shutil.which(CLI_NAME) is None:
+            with contextlib.suppress(Exception):
+                sys.stdin.buffer.read()  # drain stdin
+            return 0
+
+        try:
+            raw = sys.stdin.buffer.read()
+        except Exception:  # nosec B110
+            return 0
+
+        try:
+            result = subprocess.run(  # nosec B603 B607 - shutil.which guard validates path
+                [CLI_NAME, "hook", "claude-code", EVENT_NAME],
+                input=raw,
+                capture_output=True,
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return 0
+
+        with contextlib.suppress(Exception):
+            sys.stdout.buffer.write(result.stdout)
+            sys.stdout.buffer.flush()
+        with contextlib.suppress(Exception):
+            sys.stderr.buffer.write(result.stderr)
+            sys.stderr.buffer.flush()
+        return result.returncode
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/context-mode-test-runner-reminder.py
+++ b/tools/hooks/ai/context-mode-test-runner-reminder.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse advisory: remind Claude to use ctx_batch_execute for test commands.
+
+Emits a ``hookSpecificOutput.additionalContext`` reminder when a Bash command matches
+one of the common test-runner patterns (pytest, npm test, go test, cargo test, mvn test,
+gradle test). Does not shell out to any external CLI — entirely self-contained.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+TEST_COMMAND_PATTERNS: tuple[str, ...] = (
+    r"\bpytest\b",
+    r"\bnpm\s+(?:run\s+)?test\b",
+    r"\bgo\s+test\b",
+    r"\bcargo\s+test\b",
+    r"\bmvn\s+test\b",
+    r"\bgradle\s+test\b",
+)
+REMINDER = (
+    "Reminder: this command can produce large output. If `context-mode` MCP is "
+    "available, prefer `ctx_batch_execute` for multi-command runs (test + lint + "
+    "typecheck). Output is summarised; use `ctx_search` to retrieve detail."
+)
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; tests call this directly."""
+    try:
+        try:
+            data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0
+        if not isinstance(data, dict) or data.get("tool_name") != "Bash":
+            return 0
+        cmd = (data.get("tool_input") or {}).get("command", "")
+        if not isinstance(cmd, str) or not any(re.search(p, cmd) for p in TEST_COMMAND_PATTERNS):
+            return 0
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": REMINDER,
+            }
+        }
+        sys.stdout.write(json.dumps(output))
+        sys.stdout.flush()
+    except Exception:  # nosec B110
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/precompact-checkpoint.py
+++ b/tools/hooks/ai/precompact-checkpoint.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Claude Code PreCompact hook that synthesizes a checkpoint before context compaction.
+
+Triggered when Claude Code is about to compact the conversation context. Reads the
+transcript, spawns a headless ``claude -p`` to synthesize a structured checkpoint,
+and writes the result to ``tmp/checkpoints/{inv_epoch}-auto-precompact.md``.
+
+The hook is best-effort: any failure (timeout, missing CLI, non-zero exit, JSON parse
+failure, missing transcript) falls back to a banner + raw transcript tail tagged
+``AUTO_PARTIAL``. Always exits 0 so it never blocks the compaction event.
+
+For full documentation, see: docs/development/ai/auto-checkpoint-hook.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import subprocess  # nosec B404 - required to invoke claude CLI
+import sys
+import time
+from pathlib import Path
+
+# Maximum transcript bytes to include in the synthesis prompt.
+TRANSCRIPT_TAIL_BYTES = 200_000
+
+# Timeout for the synthesis subprocess (seconds). Set to 90 per issue #513 note.
+SYNTHESIS_TIMEOUT_SECONDS = 90
+
+# JSON schema the synthesis prompt asks for.
+SYNTHESIS_SCHEMA = (
+    "{title, status, in_flight_work, constraints, files_touched (array), next_steps, resume_prompt}"
+)
+
+# Prompt sent to the headless claude -p call.
+SYNTHESIS_PROMPT_TEMPLATE = """\
+You are summarizing a coding session for checkpoint/restore. \
+Read the transcript excerpt below and produce ONLY a JSON object with EXACTLY these keys \
+(no extra prose, no markdown fences, just the raw JSON):
+
+{schema}
+
+Field guidance:
+- title: short description of current work (e.g. "Add caching layer to user service")
+- status: one-line summary of what has landed recently and what is in-flight
+- in_flight_work: detailed description of what is currently being worked on
+- constraints: key decisions, preferences, or constraints from this session to preserve
+- files_touched: array of file paths that have been created or modified
+- next_steps: ordered list of next actions the future session should take
+- resume_prompt: a self-contained paste-ready prompt for a future agent session
+
+TRANSCRIPT (last {byte_count} bytes):
+{transcript}
+""".strip()
+
+# Markdown template for the rendered checkpoint.
+CHECKPOINT_TEMPLATE = """\
+# Auto-Checkpoint: {title}
+
+> **AUTO-PRECOMPACT** checkpoint written by the PreCompact hook before context compaction.
+> Restore with `/restore auto-precompact` in a fresh session.
+
+## Status
+
+{status}
+
+## In-Flight Work
+
+{in_flight_work}
+
+## Constraints to Preserve
+
+{constraints}
+
+## Files Touched
+
+{files_touched}
+
+## Next Steps
+
+{next_steps}
+
+## Resume Prompt
+
+{resume_prompt}
+""".strip()
+
+
+def _inv_epoch() -> str:
+    """Return a 10-digit decreasing integer string (newest sorts first)."""
+    return f"{9_999_999_999 - int(time.time()):010d}"
+
+
+def _unique_path(checkpoints_dir: Path, slug: str) -> Path:
+    """Return a unique path under *checkpoints_dir* for *slug*.
+
+    On collision (same-second invocation), appends ``-a``, ``-b``, … to the
+    epoch prefix until a free name is found.
+    """
+    epoch = _inv_epoch()
+    candidate = checkpoints_dir / f"{epoch}-{slug}.md"
+    if not candidate.exists():
+        return candidate
+    for ch in "abcdefghijklmnopqrstuvwxyz":
+        candidate = checkpoints_dir / f"{epoch}-{slug}-{ch}.md"
+        if not candidate.exists():
+            return candidate
+    # Extremely unlikely: fall back to a microsecond suffix.
+    candidate = checkpoints_dir / f"{epoch}-{slug}-x{time.time_ns()}.md"
+    return candidate
+
+
+def synthesize_checkpoint(transcript_tail: str) -> dict[str, object] | None:
+    """Call headless ``claude -p`` with a synthesis prompt; return parsed JSON or None.
+
+    Returns None immediately when *transcript_tail* is empty (nothing to synthesize).
+    """
+    if not transcript_tail:
+        return None
+    prompt = SYNTHESIS_PROMPT_TEMPLATE.format(
+        schema=SYNTHESIS_SCHEMA,
+        byte_count=len(transcript_tail.encode("utf-8", errors="replace")),
+        transcript=transcript_tail,
+    )
+    try:
+        result = subprocess.run(  # nosec B603 B607 - spawns claude CLI for synthesis
+            [
+                "claude",
+                "-p",
+                "--bare",
+                "--model",
+                "claude-sonnet-4-6",
+                prompt,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=SYNTHESIS_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            return None
+        raw = result.stdout.strip()
+        # Strip markdown fences if the model wrapped the JSON anyway.
+        if raw.startswith("```"):
+            lines = raw.splitlines()
+            raw = "\n".join(line for line in lines if not line.startswith("```")).strip()
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            return None
+        return parsed
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    except json.JSONDecodeError:
+        return None
+    except Exception:  # nosec B110 - hook must never raise
+        return None
+
+
+def _render_checkpoint(data: dict[str, object]) -> str:
+    """Render *data* dict into the markdown checkpoint format."""
+    files_touched = data.get("files_touched", [])
+    if isinstance(files_touched, list):
+        files_str = "\n".join(f"- {f}" for f in files_touched) or "_none recorded_"
+    else:
+        files_str = str(files_touched)
+
+    return CHECKPOINT_TEMPLATE.format(
+        title=data.get("title", "Unknown"),
+        status=data.get("status", "_not recorded_"),
+        in_flight_work=data.get("in_flight_work", "_not recorded_"),
+        constraints=data.get("constraints", "_none recorded_"),
+        files_touched=files_str,
+        next_steps=data.get("next_steps", "_not recorded_"),
+        resume_prompt=data.get("resume_prompt", "_not recorded_"),
+    )
+
+
+def _fallback_checkpoint(transcript_tail: str, reason: str) -> str:
+    """Return an AUTO_PARTIAL checkpoint with a raw transcript tail."""
+    return (
+        f"# Auto-Checkpoint (AUTO_PARTIAL)\n\n"
+        f"> **AUTO_PARTIAL**: synthesis failed ({reason}). "
+        f"Raw transcript tail follows.\n\n"
+        f"## Raw Transcript Tail\n\n"
+        f"```\n{transcript_tail}\n```"
+    )
+
+
+def _read_transcript_tail(transcript_path: str) -> str | None:
+    """Read and return the tail of the JSONL transcript file, or None on error."""
+    try:
+        path = Path(transcript_path)
+        if not path.is_file():
+            return None
+        size = path.stat().st_size
+        if size == 0:
+            return ""
+        with path.open("rb") as fh:
+            if size > TRANSCRIPT_TAIL_BYTES:
+                fh.seek(size - TRANSCRIPT_TAIL_BYTES)
+            raw_bytes = fh.read()
+        return raw_bytes.decode("utf-8", errors="replace")
+    except (OSError, PermissionError):
+        return None
+    except Exception:  # nosec B110 - defensive
+        return None
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; tests call this directly."""
+    try:
+        try:
+            input_data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0
+
+        if not isinstance(input_data, dict):
+            return 0
+
+        cwd = input_data.get("cwd", "")
+        transcript_path = input_data.get("transcript_path", "")
+
+        # Determine project root (cwd or CLAUDE_PROJECT_DIR).
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "") or cwd
+        if not project_dir:
+            return 0
+
+        checkpoints_dir = Path(project_dir) / "tmp" / "checkpoints"
+        try:
+            checkpoints_dir.mkdir(parents=True, exist_ok=True)
+        except (OSError, PermissionError):
+            return 0
+
+        # Read transcript tail.
+        transcript_tail: str = ""
+        if transcript_path:
+            tail = _read_transcript_tail(transcript_path)
+            if tail is not None:
+                transcript_tail = tail
+            # If tail is None (file missing/unreadable), proceed with empty tail → fallback.
+
+        # Synthesize checkpoint (always attempt; returns None on empty/failure).
+        synthesized: dict[str, object] | None = synthesize_checkpoint(transcript_tail)
+
+        # Render content.
+        if synthesized is not None:
+            try:
+                content = _render_checkpoint(synthesized)
+            except Exception:  # nosec B110 - defensive render failure
+                content = _fallback_checkpoint(transcript_tail, "render error")
+        else:
+            reason = "synthesis returned None" if transcript_tail else "no transcript"
+            content = _fallback_checkpoint(transcript_tail, reason)
+
+        # Write the checkpoint file.
+        out_path = _unique_path(checkpoints_dir, "auto-precompact")
+        with contextlib.suppress(OSError, PermissionError):
+            out_path.write_text(content, encoding="utf-8")
+
+    except Exception:  # hook must never raise
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/session-resume-restore.py
+++ b/tools/hooks/ai/session-resume-restore.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Claude Code SessionStart hook that restores the most recent auto-precompact checkpoint.
+
+Triggered when Claude Code starts a session whose trigger contains "compact" or "resume"
+(configured via the matcher in ``.claude/settings.json``). Reads the newest
+``*-auto-precompact*.md`` from ``tmp/checkpoints/`` and injects its contents into the
+new session via ``hookSpecificOutput.additionalContext``.
+
+Opt-out: set ``CLAUDE_NO_AUTO_RESTORE=1`` to disable restoration entirely.
+Widen: set ``CLAUDE_RESTORE_ANY=1`` to restore any ``*.md`` checkpoint, not just
+``*-auto-precompact*.md`` ones.
+
+The hook is best-effort: any failure (missing directory, no matching files, malformed
+stdin) is swallowed and the hook exits 0 so it never blocks session startup.
+
+For full documentation, see: docs/development/ai/auto-checkpoint-hook.md
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Default glob: only auto-precompact checkpoints.
+DEFAULT_GLOB = "*-auto-precompact*.md"
+
+# Widened glob: any checkpoint (enabled when CLAUDE_RESTORE_ANY=1).
+ANY_GLOB = "*.md"
+
+
+def _find_newest_checkpoint(checkpoints_dir: Path, glob: str) -> Path | None:
+    """Return the lexically smallest (newest by inv_epoch) matching file, or None."""
+    try:
+        matches = sorted(checkpoints_dir.glob(glob))
+        return matches[0] if matches else None
+    except (OSError, PermissionError):
+        return None
+    except Exception:  # nosec B110 - defensive
+        return None
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; tests call this directly."""
+    try:
+        # Opt-out check.
+        if os.environ.get("CLAUDE_NO_AUTO_RESTORE"):
+            return 0
+
+        try:
+            input_data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0
+
+        if not isinstance(input_data, dict):
+            return 0
+
+        cwd = input_data.get("cwd", "")
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "") or cwd
+        if not project_dir:
+            return 0
+
+        checkpoints_dir = Path(project_dir) / "tmp" / "checkpoints"
+        if not checkpoints_dir.is_dir():
+            return 0
+
+        # Choose glob based on env var.
+        glob = ANY_GLOB if os.environ.get("CLAUDE_RESTORE_ANY") else DEFAULT_GLOB
+
+        newest = _find_newest_checkpoint(checkpoints_dir, glob)
+        if newest is None:
+            return 0
+
+        try:
+            body = newest.read_text(encoding="utf-8")
+        except (OSError, PermissionError):
+            return 0
+        except Exception:  # nosec B110 - defensive
+            return 0
+
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": body,
+            }
+        }
+        sys.stdout.write(json.dumps(output))
+        sys.stdout.flush()
+
+    except Exception:  # hook must never raise
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/test_hook.py
+++ b/tools/hooks/ai/test_hook.py
@@ -6,8 +6,13 @@ Run this after making changes to the lexer or patterns to verify behavior.
 
 Usage (from any directory):
     python3 /path/to/project/tools/hooks/ai/test_hook.py
+
+Pass ALLOW_AI_READY_TO_MERGE=1 to exercise the bypass path:
+    ALLOW_AI_READY_TO_MERGE=1 python3 /path/to/project/tools/hooks/ai/test_hook.py
 """
 
+import json
+import os
 import subprocess  # nosec B404 - needed to run hook for testing
 import sys
 from pathlib import Path
@@ -21,8 +26,10 @@ RESET = "\033[0m"
 # Use resolve() to get absolute path so it works from any directory
 HOOK_PATH = (Path(__file__).parent / "block-dangerous-commands.py").resolve()
 
-# Test cases: (command, expected_result, description)
+# ---------------------------------------------------------------------------
+# Bash test cases: (command, expected_result, description)
 # expected_result: 'ALLOW' or 'BLOCK'
+# ---------------------------------------------------------------------------
 TESTS = [
     # === SHOULD ALLOW - Safe commands ===
     ("git status", "ALLOW", "safe command"),
@@ -110,7 +117,7 @@ EOF
     ("doit test", "ALLOW", "doit test"),
     ("doit pr", "ALLOW", "doit pr"),
     ("doit issue --type=bug", "ALLOW", "doit issue"),
-    # === SHOULD BLOCK - Governance labels ===
+    # === SHOULD BLOCK - Governance labels (no env var) ===
     ("gh pr edit 123 --add-label ready-to-merge", "BLOCK", "add ready-to-merge"),
     ("gh pr edit --add-label ready-to-merge", "BLOCK", "add ready-to-merge no PR"),
     ("gh issue edit 45 --add-label ready-to-merge", "BLOCK", "issue ready-to-merge"),
@@ -136,16 +143,261 @@ EOF
     ("gh pr view 456", "ALLOW", "gh pr view"),
     ("gh issue close 123", "ALLOW", "gh issue close"),
     ("gh pr close 123", "ALLOW", "gh pr close"),
+    # === SHOULD BLOCK - Bash env-var persistence (no env var) ===
+    (
+        'echo "ALLOW_AI_READY_TO_MERGE=1" >> ~/.bashrc',
+        "BLOCK",
+        "persist rtm var to .bashrc",
+    ),
+    (
+        "tee -a ~/.zshrc <<< 'export ALLOW_AI_READY_TO_MERGE=1'",
+        "BLOCK",
+        "persist rtm var to .zshrc",
+    ),
+    # === SHOULD ALLOW - Bash write to non-protected target ===
+    (
+        'echo "ALLOW_AI_READY_TO_MERGE=1" >> /tmp/notes.txt',
+        "ALLOW",
+        "rtm var to non-protected file",
+    ),
+    # === SHOULD ALLOW - Bash write to protected file but no var name ===
+    (
+        'echo "PATH=/foo" >> ~/.bashrc',
+        "ALLOW",
+        "no var name write to .bashrc",
+    ),
+    # === SHOULD ALLOW - var name appears but no write to a protected target ===
+    # `git add` lists protected files as positional args and the commit message
+    # mentions the var name; this is staging code + composing a commit, not a
+    # write that persists the var into the file system.
+    (
+        'git add .claude/settings.json && git commit -m "doc: mention ALLOW_AI_READY_TO_MERGE"',
+        "ALLOW",
+        "git add + commit message mentions var",
+    ),
+    (
+        'echo "ALLOW_AI_READY_TO_MERGE is the env var" ',
+        "ALLOW",
+        "var name in echo without redirect",
+    ),
+    (
+        "grep ALLOW_AI_READY_TO_MERGE .claude/settings.json",
+        "ALLOW",
+        "grep var name in protected file",
+    ),
+    (
+        "cat .claude/settings.json | head -5 # ALLOW_AI_READY_TO_MERGE",
+        "ALLOW",
+        "read protected file with var in comment",
+    ),
+    # === SHOULD BLOCK - Additional persistence write patterns ===
+    (
+        "sed -i 's/X/ALLOW_AI_READY_TO_MERGE=1/' ~/.bashrc",
+        "BLOCK",
+        "sed -i in-place edit on .bashrc",
+    ),
+    (
+        "python -c \"open('/home/me/.bashrc','a').write('ALLOW_AI_READY_TO_MERGE=1')\"",
+        "BLOCK",
+        "python -c writing var to .bashrc",
+    ),
+    (
+        'echo "ALLOW_AI_READY_TO_MERGE=1" >>~/.bashrc',
+        "BLOCK",
+        "no-space redirect to .bashrc",
+    ),
+    # === SHOULD ALLOW - similar but not actually writing ===
+    (
+        "sed 's/X/ALLOW_AI_READY_TO_MERGE=1/' ~/.bashrc",
+        "ALLOW",
+        "sed without -i (read-only) on .bashrc",
+    ),
+    (
+        "python script.py # ALLOW_AI_READY_TO_MERGE",
+        "ALLOW",
+        "python without -c flag",
+    ),
+    (
+        "python -c \"print('ALLOW_AI_READY_TO_MERGE')\"",
+        "ALLOW",
+        "python -c print var name only",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Governance label bypass tests — run with ALLOW_AI_READY_TO_MERGE=1 in env
+# ---------------------------------------------------------------------------
+# These are like TESTS but the bypass env var is injected per subprocess call.
+BYPASS_TESTS = [
+    # === SHOULD ALLOW when env var is set ===
+    (
+        "gh pr edit 123 --add-label ready-to-merge",
+        "ALLOW",
+        "rtm label with bypass var",
+    ),
+    (
+        "gh pr edit --add-label ready-to-merge",
+        "ALLOW",
+        "rtm label no PR with bypass var",
+    ),
+    (
+        "gh issue edit 45 --add-label ready-to-merge",
+        "ALLOW",
+        "issue rtm label with bypass var",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# File-edit test cases: (tool_name, tool_input_dict, expected, description)
+# expected: 'ALLOW' or 'BLOCK'
+# ---------------------------------------------------------------------------
+EDIT_TESTS = [
+    # Edit ~/.bashrc adding the env var name → BLOCK
+    (
+        "Edit",
+        {
+            "file_path": "~/.bashrc",
+            "old_string": "",
+            "new_string": "export ALLOW_AI_READY_TO_MERGE=1",
+        },
+        "BLOCK",
+        "Edit .bashrc adding rtm var",
+    ),
+    # Edit .envrc adding the var → BLOCK
+    (
+        "Edit",
+        {
+            "file_path": ".envrc",
+            "old_string": "",
+            "new_string": "export ALLOW_AI_READY_TO_MERGE=1",
+        },
+        "BLOCK",
+        "Edit .envrc adding rtm var",
+    ),
+    # Write .claude/settings.local.json containing the var → BLOCK
+    (
+        "Write",
+        {
+            "file_path": ".claude/settings.local.json",
+            "content": '{"env": {"ALLOW_AI_READY_TO_MERGE": "1"}}',
+        },
+        "BLOCK",
+        "Write claude settings.local.json with rtm var",
+    ),
+    # Edit ~/.bashrc with unrelated content (no env var name) → ALLOW
+    (
+        "Edit",
+        {
+            "file_path": "~/.bashrc",
+            "old_string": "",
+            "new_string": "export PATH=$PATH:/usr/local/bin",
+        },
+        "ALLOW",
+        "Edit .bashrc unrelated content",
+    ),
+    # Edit /tmp/scratch.txt adding the var (target not protected) → ALLOW
+    (
+        "Edit",
+        {
+            "file_path": "/tmp/scratch.txt",  # nosec B108 - test data, not a real tmp file
+            "old_string": "",
+            "new_string": "export ALLOW_AI_READY_TO_MERGE=1",
+        },
+        "ALLOW",
+        "Edit non-protected file with rtm var",
+    ),
+    # MultiEdit on ~/.zshrc where one edit adds the var → BLOCK
+    (
+        "MultiEdit",
+        {
+            "file_path": "~/.zshrc",
+            "edits": [
+                {"old_string": "# aliases", "new_string": "# aliases\nalias ll='ls -la'"},
+                {
+                    "old_string": "# env",
+                    "new_string": "# env\nexport ALLOW_AI_READY_TO_MERGE=1",
+                },
+            ],
+        },
+        "BLOCK",
+        "MultiEdit .zshrc one edit has rtm var",
+    ),
+    # Gemini write_file to .envrc → BLOCK
+    (
+        "write_file",
+        {
+            "file_path": ".envrc",
+            "content": "export ALLOW_AI_READY_TO_MERGE=1\n",
+        },
+        "BLOCK",
+        "Gemini write_file to .envrc with rtm var",
+    ),
+    # Gemini replace on ~/.bashrc → BLOCK
+    (
+        "replace",
+        {
+            "file_path": "~/.bashrc",
+            "old_string": "",
+            "new_string": "export ALLOW_AI_READY_TO_MERGE=1",
+        },
+        "BLOCK",
+        "Gemini replace .bashrc with rtm var",
+    ),
+    # Gemini write_file to unprotected file → ALLOW
+    (
+        "write_file",
+        {
+            "file_path": "/tmp/scratch.txt",  # nosec B108 - test data, not a real tmp file
+            "content": "export ALLOW_AI_READY_TO_MERGE=1\n",
+        },
+        "ALLOW",
+        "Gemini write_file non-protected with rtm var",
+    ),
+    # Copilot format: Edit via toolName/toolArgs → BLOCK
+    # (tested in run_edit_test via copilot_format flag)
+]
+
+# Copilot-format file-edit tests: same shape but using camelCase hook input
+# (tool_name, tool_input_dict, expected, description)
+COPILOT_EDIT_TESTS = [
+    (
+        "Edit",
+        {
+            "file_path": "~/.bashrc",
+            "old_string": "",
+            "new_string": "export ALLOW_AI_READY_TO_MERGE=1",
+        },
+        "BLOCK",
+        "Copilot Edit .bashrc adding rtm var",
+    ),
+    (
+        "Edit",
+        {
+            "file_path": "~/.bashrc",
+            "old_string": "",
+            "new_string": "export PATH=$PATH:/usr/local/bin",
+        },
+        "ALLOW",
+        "Copilot Edit .bashrc unrelated content",
+    ),
 ]
 
 
-def run_test(cmd: str, expected: str, desc: str) -> bool:
-    """Run a single test and return True if it passed."""
-    import json
-
+def run_test(
+    cmd: str,
+    expected: str,
+    desc: str,
+    extra_env: dict[str, str] | None = None,
+) -> bool:
+    """Run a single Bash-tool test and return True if it passed."""
     json_input = json.dumps({"tool_name": "Bash", "tool_input": {"command": cmd}})
+    env = {**os.environ, **(extra_env or {})}
     result = subprocess.run(
-        ["python3", str(HOOK_PATH)], input=json_input, capture_output=True, text=True
+        ["python3", str(HOOK_PATH)],
+        input=json_input,
+        capture_output=True,
+        text=True,
+        env=env,
     )
     actual = "BLOCK" if result.returncode == 2 else "ALLOW"
     passed = actual == expected
@@ -165,6 +417,63 @@ def run_test(cmd: str, expected: str, desc: str) -> bool:
     return passed
 
 
+def run_edit_test(
+    tool_name: str,
+    tool_input: dict,
+    expected: str,
+    desc: str,
+    copilot_format: bool = False,
+    extra_env: dict[str, str] | None = None,
+) -> bool:
+    """Run a single file-edit-tool test and return True if it passed."""
+    if copilot_format:
+        json_input = json.dumps(
+            {
+                "toolName": tool_name,
+                "toolArgs": json.dumps(tool_input),
+            }
+        )
+    else:
+        json_input = json.dumps(
+            {
+                "tool_name": tool_name,
+                "tool_input": tool_input,
+            }
+        )
+
+    env = {**os.environ, **(extra_env or {})}
+    result = subprocess.run(
+        ["python3", str(HOOK_PATH)],
+        input=json_input,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    # Copilot denials return exit 0 with JSON stdout; non-copilot denials return exit 2
+    if copilot_format:
+        try:
+            out = json.loads(result.stdout)
+            actual = "BLOCK" if out.get("permissionDecision") == "deny" else "ALLOW"
+        except (json.JSONDecodeError, AttributeError):
+            actual = "ALLOW"
+    else:
+        actual = "BLOCK" if result.returncode == 2 else "ALLOW"
+
+    passed = actual == expected
+    mark = "+" if passed else "X"
+    color = GREEN if passed else RED
+
+    label = f"[copilot] {desc}" if copilot_format else desc
+    print(f"{color}{mark} {actual:5} (expected {expected:5}) | {label:35} | {tool_name}{RESET}")
+
+    if not passed:
+        print(f"{RED}  stderr: {result.stderr[:200] if result.stderr else '(none)'}{RESET}")
+        if copilot_format and result.stdout:
+            print(f"{RED}  stdout: {result.stdout[:200]}{RESET}")
+
+    return passed
+
+
 def main() -> int:
     """Run all tests and return exit code."""
     print(f"Testing hook: {HOOK_PATH}\n")
@@ -173,8 +482,35 @@ def main() -> int:
     passed = 0
     failed = 0
 
+    # --- Bash command tests (no env var) ---
+    print("\n[Bash command tests — no bypass env var]")
     for cmd, expected, desc in TESTS:
         if run_test(cmd, expected, desc):
+            passed += 1
+        else:
+            failed += 1
+
+    # --- Governance label bypass tests (env var injected per test) ---
+    print("\n[Governance label bypass tests — ALLOW_AI_READY_TO_MERGE=1 injected]")
+    bypass_env = {"ALLOW_AI_READY_TO_MERGE": "1"}
+    for cmd, expected, desc in BYPASS_TESTS:
+        if run_test(cmd, expected, desc, extra_env=bypass_env):
+            passed += 1
+        else:
+            failed += 1
+
+    # --- File-edit tests (Claude/Codex/Gemini format) ---
+    print("\n[File-edit tests — Claude/Codex/Gemini format]")
+    for tool_name, tool_input, expected, desc in EDIT_TESTS:
+        if run_edit_test(tool_name, tool_input, expected, desc):
+            passed += 1
+        else:
+            failed += 1
+
+    # --- File-edit tests (Copilot format) ---
+    print("\n[File-edit tests — Copilot format]")
+    for tool_name, tool_input, expected, desc in COPILOT_EDIT_TESTS:
+        if run_edit_test(tool_name, tool_input, expected, desc, copilot_format=True):
             passed += 1
         else:
             failed += 1


### PR DESCRIPTION
## Description

PR **2 of 4** for the pyproject-template sync (170df8c9 → e3d32ea). This PR
covers the AI hooks layer only. Issue #64 stays open until PR 4 (docs/statusline/sync-mark) is merged.

- **PR 1 (merged):** doit tooling, deps, CI
- **PR 2 (this PR):** AI hooks — `tools/hooks/ai/`, hook tests, AI config files
- **PR 3 (upcoming):** commands/skills (`.claude/commands/`, `.gemini/commands/`, `.agents/skills/`)
- **PR 4 (upcoming):** docs, statusline, sync-mark

## Related Issue

Addresses #64

## Type of Change

- [x] Code refactoring
- [x] New feature (non-breaking change which adds functionality)

## Changes Made

### New hook scripts (`tools/hooks/ai/`)

Twelve new scripts synced from the template:

- `precompact-checkpoint.py` — saves a checkpoint summary before Claude compacts context
- `session-resume-restore.py` — restores that checkpoint on session start (compact/resume)
- `context-mode-sessionstart.py`, `context-mode-pretooluse.py`, `context-mode-posttooluse.py`, `context-mode-precompact.py`, `context-mode-test-runner-reminder.py` — context-mode awareness hooks (opt-in, unwired)
- `cbm-code-discovery-gate.py`, `cbm-mcp-marker.py`, `cbm-session-reminder.py`, `cbm-session-reminder.md` — Codebase Memory MCP hooks (opt-in, unwired; `cbm-code-discovery-gate` is fail-closed without the MCP)
- `bash-ban-raw-tools.py` — enforces Read/Grep/Glob/Edit/Write over shell equivalents (opt-in, unwired)

### Updated hook (`tools/hooks/ai/block-dangerous-commands.py`)

Additive changes only — all prior blocking preserved:

- Added `Edit | Write | MultiEdit` tool path (same dangerous-pattern checks now apply to file-edit tools)
- Added `ALLOW_AI_READY_TO_MERGE` env-variable protection (prevents AI agents from persisting the label env var across sessions)

### Hook self-tests (`tools/hooks/ai/test_hook.py` + `tests/test_hook_*.py`)

- `test_hook.py` updated for the new Edit/Write/MultiEdit path and `ALLOW_AI_READY_TO_MERGE` cases: **102 tests, 102 passing**
- 11 new pytest test files added for every new hook script (cbm-*, context-mode-*, precompact-checkpoint, session-resume-restore, bash-ban-raw-tools)

### `.claude/settings.json` — safe defaults only

Wired hooks (active immediately):

- `block-dangerous-commands` — now also on `Edit | Write | MultiEdit` PreToolUse matchers
- `precompact-checkpoint` — wired to PreCompact
- `session-resume-restore` — wired to SessionStart (compact + resume event types)

New `env` block (takes effect in future Claude Code sessions in this repo):

- `ENABLE_PROMPT_CACHING_1H=1`
- `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50`
- `CLAUDE_CODE_SUBAGENT_MODEL=claude-sonnet-4-6`

**Present but UNWIRED (opt-in, off by default):**

`cbm-*`, `context-mode-*`, and `bash-ban-raw-tools` are present in
`tools/hooks/ai/` but are **not wired** in `.claude/settings.json`. They are
opt-in add-ons. In particular, `cbm-code-discovery-gate` is **fail-closed**:
it would block `Read`, `Grep`, and `Glob` tool calls unless the Codebase
Memory MCP server is active — so it must never be enabled without that MCP.
Enablement instructions will be documented in
`docs/development/ai/token-efficiency-add-ons.md` (synced in PR 4).

Preserved project-specific config: `statusLine` custom format; existing
`ruff-fix-on-edit` PostToolUse wiring.

### `.gemini/settings.json`

- Preserved curated tool allow-list, sandbox settings, UI/context config
- Deferred the template's `skills.disabled` block and general-behavior additions to PR 3

### `.codex/config.toml`

- Added `Edit|Write|MultiEdit` tool-path matchers to the `block-dangerous-commands` hook entry

## Testing

- [x] All existing tests pass (`doit check` — format, lint, type-check, security, audit, spell, tests all green)
- [x] Added new tests for all new hook scripts (11 new pytest files)
- [x] Hook self-test: `python3 tools/hooks/ai/test_hook.py` — 102 passed, 0 failed
- [x] Manually verified hook wiring in `.claude/settings.json`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — N/A for PR 2; hook docs (`command-blocking.md`, `token-efficiency-add-ons.md`) are PR 4 scope
- [x] My changes generate no new warnings

## Additional Notes

**No ADR required:** Issue #64 is a chore/template-sync with no `needs-adr` label. The `block-dangerous-commands` additions are additive; ADR-9005 covers the existing decision and does not need an issue link update for a template sync.

**New env vars are forward-only:** `ENABLE_PROMPT_CACHING_1H`, `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, and `CLAUDE_CODE_SUBAGENT_MODEL` take effect in future Claude Code sessions opened in this repo — they do not affect the current session retroactively.

**Issue #64 remains open** until PR 4 (docs/statusline/sync-mark) is merged.
