### PR TITLE
chore: sync docs, statusline & record sync point (PR 4 of 4)

### DIFF
--- a/.claude/agents/implement-worker.md
+++ b/.claude/agents/implement-worker.md
@@ -1,15 +1,15 @@
 ---
 name: implement-worker
 description: >-
-  Performs the implementation step of the /implement workflow after the
+  Performs the implementation step of the /claude:implement workflow after the
   plan comment exists and the branch is created. Reads project rules,
   fetches the plan, edits files, writes tests, and runs `doit check`.
-  Do NOT invoke directly — /implement drives this subagent.
+  Do NOT invoke directly — /claude:implement drives this subagent.
 tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 permissionMode: default
 ---
 
-You implement a GitHub issue's approved plan on an already-created branch. The parent `/implement` command has verified preconditions and created the branch; your job is to read the rules, fetch the plan, edit files, write tests, run `doit check`, and return a summary.
+You implement a GitHub issue's approved plan on an already-created branch. The parent `/claude:implement` command has verified preconditions and created the branch; your job is to read the rules, fetch the plan, edit files, write tests, run `doit check`, and return a summary.
 
 ## Inputs from the parent
 
@@ -61,7 +61,7 @@ Report to the parent:
 
 ## Constraints
 
-- **Do NOT switch branches.** The parent `/implement` command has already created and checked out the correct branch.
-- **Do NOT commit.** Committing is handled by the parent's `/finalize` step, not by you.
+- **Do NOT switch branches.** The parent `/claude:implement` command has already created and checked out the correct branch.
+- **Do NOT commit.** Committing is handled by the parent's `/ghi-finalize` step, not by you.
 - **Do NOT enter plan mode.** Do not call `EnterPlanMode`. You run with `permissionMode: default` so you can edit files directly.
 - **All new code must be type-annotated** (mypy strict mode is enforced by `doit check`).

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -1,0 +1,110 @@
+# Per-Stack Rule Files
+
+## Purpose
+
+Rule files in this directory capture **narrow, recurring footguns** that an AI agent keeps getting
+wrong for a specific stack or domain. They are not a second copy of `AGENTS.md`. `AGENTS.md` carries
+broad workflow and architectural rules for the whole project. A rule file carries three to ten
+numbered self-checks for one specific failure mode — small enough to survive a context window, sharp
+enough to change behavior.
+
+The pattern works because a short, skill-gated checklist is more likely to be honored late in a
+session than a paragraph buried in a large reference file.
+
+## When to author a rule file
+
+Write a rule file when all three conditions hold:
+
+1. The same mistake has recurred in at least two separate sessions or PRs.
+2. The failure can be expressed as a numbered checklist a model can self-check before acting.
+3. The scope is narrow enough to belong to a single skill gate (e.g., `codegen`, `db-migrations`,
+   `api-contracts`).
+
+If the rule is broad (applies everywhere) or is not tied to an observed failure, put it in
+`AGENTS.md` instead — or leave it out entirely.
+
+## File structure
+
+Each rule file must have three parts:
+
+```
+Skill: <name>
+
+Self-check before <action>:
+1. <First check — concrete and verifiable>
+2. <Second check>
+3. <Third check>
+...
+
+Observed failures: <PR or issue URL>, <PR or issue URL>
+```
+
+- **`Skill: <name>`** — the first line, no heading. Names the capability gate so the model can
+  self-identify when to apply the file.
+- **Numbered self-check list** — imperative, specific. Each item must be falsifiable: the model
+  should be able to answer "yes" or "no".
+- **`Observed failures:` footer** — links to the PRs or issues where the failure was documented.
+  This is mandatory. A rule with no observed-failure link is a guess, not a discipline.
+
+Target: **30 lines or fewer** per rule file. If a file grows past 30 lines, split it.
+
+## How to load
+
+Uncomment the `@./rules/*.md` line in `.claude/CLAUDE.md`:
+
+```
+@../AGENTS.md
+<!-- Uncomment when you add rule files. See .claude/rules/README.md for the pattern. -->
+<!-- @./rules/*.md -->
+```
+
+becomes:
+
+```
+@../AGENTS.md
+@./rules/*.md
+```
+
+Note: the line stays commented out in this template repository. Downstream consumers uncomment it
+after authoring their first rule file.
+
+## Discipline: build from observed failures, not generic best-practices
+
+The central rule of this pattern is that rule files must be derived from documented failures, not
+from intuition or generic advice. A checklist written in advance of any failure will drift into
+noise — the model will pattern-match the checklist language and satisfy it superficially. A
+checklist written because a specific PR broke a specific invariant three times is sharp enough to
+change behavior. If you cannot fill in the `Observed failures:` footer with real links, the rule
+file is not ready to be written yet.
+
+## Worked example
+
+The following sketch illustrates what a `codegen.md` rule file might look like for a downstream
+project (`pynetappfoundry`) that generates typed Python from a YANG schema and has an ADR
+(ADR-0008) documenting a round-trip invariant. **This example is illustrative only** — actual rule
+files belong in downstream repos, not in this template.
+
+```
+Skill: codegen
+
+Self-check before committing generated code:
+1. Run `make roundtrip` and confirm exit 0 — the generated types must deserialize
+   what the serializer produces without loss (ADR-0008).
+2. Confirm no hand-edited lines remain in `src/generated/` — regenerate from schema
+   if any exist.
+3. Confirm the schema version in `src/generated/_version.py` matches the YANG source
+   revision header.
+
+Observed failures: endavis/pynetappfoundry#104, endavis/pynetappfoundry#117
+```
+
+## What NOT to put in a rule file
+
+- **Broad workflow rules** — things like "never commit to main" or "always run `doit check`"
+  belong in `AGENTS.md`, not here. Rule files are for stack-specific self-checks, not universal
+  workflow.
+- **Generic best-practices** — "prefer composition over inheritance", "write type annotations" —
+  these are noise. They drift into checklists the model satisfies by rote without changing
+  behavior.
+- **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule
+  was violated, the rule file is not ready to be written.

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -8,6 +8,9 @@ COLOR="blue"
 C_RESET='\033[0m'
 C_GRAY='\033[38;5;245m'  # explicit gray for default text
 C_BAR_EMPTY='\033[38;5;238m'
+C_DIM="$C_BAR_EMPTY"  # semantic alias for dim separators (e.g., the `@` in usage segment)
+C_PCT='\033[38;5;71m'  # green: percentage values in usage segment (theme-independent)
+C_TIME='\033[38;5;136m'  # gold: reset-time values in usage segment (theme-independent)
 case "$COLOR" in
     orange)   C_ACCENT='\033[38;5;173m' ;;
     blue)     C_ACCENT='\033[38;5;74m' ;;
@@ -190,6 +193,29 @@ output="📁 ${dir}"
 [[ -n "$gh_user" ]] && output+="\n@${gh_user}"
 [[ -n "$branch" ]] && output+=" | 🔀 ${branch} ${git_status}"
 output+="\n${C_ACCENT}${model}${C_GRAY} | ${ctx}${C_RESET}"
+
+# Opt-in: append Claude Max usage to the model/context line when CLAUDE_USAGE_STATUSLINE=1.
+# See docs/development/ai/statusline.md#opt-in-claude-max-usage-display
+if [[ -n "$CLAUDE_USAGE_STATUSLINE" ]]; then
+    usage=$(bash "$CLAUDE_PROJECT_DIR/tools/statusline/claude-usage.sh" 2>/dev/null)
+    if [[ -n "$usage" && "$usage" != "?" ]]; then
+        # Parse the helper's plain-text output (5h:N%@HHMM wk:N%@aaa-HHMM) and
+        # rebuild it with per-field colors: labels accent, percent green,
+        # `@` dim, time gold. Middle-dot separator between gauges.
+        if [[ "$usage" =~ ^5h:([0-9]+)%@([^ ]+)\ wk:([0-9]+)%@(.+)$ ]]; then
+            fh_pct="${BASH_REMATCH[1]}"
+            fh_time="${BASH_REMATCH[2]}"
+            wk_pct="${BASH_REMATCH[3]}"
+            wk_time="${BASH_REMATCH[4]}"
+            colored="${C_ACCENT}5h:${C_PCT}${fh_pct}%${C_DIM}@${C_TIME}${fh_time}"
+            colored+="${C_GRAY} · ${C_ACCENT}wk:${C_PCT}${wk_pct}%${C_DIM}@${C_TIME}${wk_time}"
+            output+="${C_GRAY} | ${colored}${C_RESET}"
+        else
+            # Unexpected format from the helper — emit uncolored as a safe fallback.
+            output+="${C_GRAY} | ${usage}${C_RESET}"
+        fi
+    fi
+fi
 
 printf '%b\n' "$output"
 

--- a/.config/pyproject_template/settings.toml
+++ b/.config/pyproject_template/settings.toml
@@ -1,3 +1,3 @@
 [template]
-commit = "170df8c909cd3199c4dfeb866f3494cc989ea61c"
-commit_date = "2026-04-28"
+commit = "e3d32ea0e434cf373a85bde5f2d535aeb9393b99"
+commit_date = "2026-06-02"

--- a/.gemini/policies/developer.toml
+++ b/.gemini/policies/developer.toml
@@ -1,0 +1,4 @@
+[[rule]]
+toolName = "*"
+decision = "ask_user"
+priority = 100

--- a/.gemini/rules/README.md
+++ b/.gemini/rules/README.md
@@ -1,0 +1,93 @@
+# Per-Stack Rule Files (Gemini)
+
+## Purpose
+
+Rule files in this directory capture **narrow, recurring footguns** that Gemini CLI keeps getting
+wrong for a specific stack or domain. They are not a second copy of `AGENTS.md`. `AGENTS.md` carries
+broad workflow and architectural rules for the whole project. A rule file carries three to ten
+numbered self-checks for one specific failure mode — small enough to survive a context window, sharp
+enough to change behavior.
+
+The pattern works because a short, skill-gated checklist is more likely to be honored late in a
+session than a paragraph buried in a large reference file.
+
+## When to author a rule file
+
+Write a rule file when all three conditions hold:
+
+1. The same mistake has recurred in at least two separate sessions or PRs.
+2. The failure can be expressed as a numbered checklist a model can self-check before acting.
+3. The scope is narrow enough to belong to a single skill gate (e.g., `codegen`, `db-migrations`,
+   `api-contracts`).
+
+If the rule is broad (applies everywhere) or is not tied to an observed failure, put it in
+`AGENTS.md` instead — or leave it out entirely.
+
+## File structure
+
+Each rule file must have three parts:
+
+```
+Skill: <name>
+
+Self-check before <action>:
+1. <First check — concrete and verifiable>
+2. <Second check>
+3. <Third check>
+...
+
+Observed failures: <PR or issue URL>, <PR or issue URL>
+```
+
+- **`Skill: <name>`** — the first line, no heading. Names the capability gate so the model can
+  self-identify when to apply the file.
+- **Numbered self-check list** — imperative, specific. Each item must be falsifiable: the model
+  should be able to answer "yes" or "no".
+- **`Observed failures:` footer** — links to the PRs or issues where the failure was documented.
+  This is mandatory. A rule with no observed-failure link is a guess, not a discipline.
+
+Target: **30 lines or fewer** per rule file. If a file grows past 30 lines, split it.
+
+## How to load
+
+When you author a rule file (e.g., `codegen.md`), add a literal `@`-import for it to `GEMINI.md`:
+
+```markdown
+@./AGENTS.md
+@./.gemini/rules/codegen.md
+
+# Gemini CLI Instructions
+...
+```
+
+Add one line per rule file. Do **not** use a glob like `@./.gemini/rules/*.md` — Gemini CLI's
+[Memory Import Processor](https://geminicli.com/docs/reference/memport/) only supports literal
+relative or absolute paths to specific files. Globs work in practice via undocumented behavior but
+emit a spurious `[ERROR] [ImportProcessor] Failed to import .../*.md: ENOENT` log on every run
+(the processor calls `access()` on the literal pattern before expanding it).
+
+This is the inverse of Claude Code's `.claude/CLAUDE.md`, which does support glob imports — the two
+CLIs differ here despite using the same `@`-import syntax.
+
+Note: this template ships with no import line in `GEMINI.md`. Add the first line when you author
+your first rule file.
+
+## Discipline: build from observed failures, not generic best-practices
+
+The central rule of this pattern is that rule files must be derived from documented failures, not
+from intuition or generic advice. A checklist written in advance of any failure will drift into
+noise — the model will pattern-match the checklist language and satisfy it superficially. A
+checklist written because a specific PR broke a specific invariant three times is sharp enough to
+change behavior. If you cannot fill in the `Observed failures:` footer with real links, the rule
+file is not ready to be written yet.
+
+## What NOT to put in a rule file
+
+- **Broad workflow rules** — things like "never commit to main" or "always run `doit check`"
+  belong in `AGENTS.md`, not here. Rule files are for stack-specific self-checks, not universal
+  workflow.
+- **Generic best-practices** — "prefer composition over inheritance", "write type annotations" —
+  these are noise. They drift into checklists the model satisfies by rote without changing
+  behavior.
+- **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule
+  was violated, the rule file is not ready to be written.

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -1,0 +1,135 @@
+# Per-Stack Instruction Files (GitHub Copilot)
+
+## Purpose
+
+Instruction files in this directory capture **narrow, recurring footguns** that GitHub Copilot
+keeps getting wrong for a specific stack or domain. They are not a second copy of `AGENTS.md`.
+`AGENTS.md` carries broad workflow and architectural rules for the whole project. An instruction
+file carries three to ten numbered self-checks for one specific failure mode — small enough to
+survive a context window, sharp enough to change behavior.
+
+The pattern works because a short, skill-gated checklist is more likely to be honored late in a
+session than a paragraph buried in a large reference file.
+
+> **Copilot-native format:** Files in this directory are consumed by GitHub Copilot via its native
+> auto-discovery mechanism. Claude Code and Gemini CLI **cannot** read `.github/instructions/`
+> files. For the Claude equivalent use `.claude/rules/`; for the Gemini equivalent use
+> `.gemini/rules/`.
+
+## When to author an instruction file
+
+Write an instruction file when all three conditions hold:
+
+1. The same mistake has recurred in at least two separate sessions or PRs.
+2. The failure can be expressed as a numbered checklist a model can self-check before acting.
+3. The scope is narrow enough to belong to a single skill gate (e.g., `codegen`, `db-migrations`,
+   `api-contracts`).
+
+If the rule is broad (applies everywhere) or is not tied to an observed failure, put it in
+`AGENTS.md` instead — or leave it out entirely.
+
+## File naming and location
+
+Files must be placed directly in `.github/instructions/` and named `NAME.instructions.md`.
+Copilot auto-discovers all `*.instructions.md` files in this directory — no explicit import or
+directive is required.
+
+## File structure
+
+Each instruction file must begin with YAML frontmatter that gates the file to a path scope,
+followed by three required sections:
+
+```
+---
+applyTo: 'src/**/*.py'
+---
+Skill: <name>
+
+Self-check before <action>:
+1. <First check — concrete and verifiable>
+2. <Second check>
+3. <Third check>
+...
+
+Observed failures: <PR or issue URL>, <PR or issue URL>
+```
+
+### `applyTo:` frontmatter
+
+The `applyTo:` field is **required**. It is a glob pattern that gates the file to specific paths:
+
+- `applyTo: '**'` — applies repo-wide (equivalent to Claude's `@./rules/*.md` with no path filter)
+- `applyTo: 'src/**/*.py'` — scopes to Python source files only
+- `applyTo: 'tests/**'` — scopes to test files only
+
+Use a narrow glob when the self-checks are only relevant for a specific subtree.
+
+### Body sections
+
+- **`Skill: <name>`** — the first line after frontmatter, no heading. Names the capability gate so
+  the model can self-identify when to apply the file.
+- **Numbered self-check list** — imperative, specific. Each item must be falsifiable: the model
+  should be able to answer "yes" or "no".
+- **`Observed failures:` footer** — links to the PRs or issues where the failure was documented.
+  This is mandatory. A rule with no observed-failure link is a guess, not a discipline.
+
+Target: **30 lines or fewer** per instruction file (excluding frontmatter). If a file grows past
+30 lines, split it.
+
+## Discipline: build from observed failures, not generic best-practices
+
+The central rule of this pattern is that instruction files must be derived from documented
+failures, not from intuition or generic advice. A checklist written in advance of any failure will
+drift into noise — the model will pattern-match the checklist language and satisfy it
+superficially. A checklist written because a specific PR broke a specific invariant three times is
+sharp enough to change behavior. If you cannot fill in the `Observed failures:` footer with real
+links, the instruction file is not ready to be written yet.
+
+## Worked example
+
+The following sketch illustrates what a `codegen.instructions.md` file might look like for a
+downstream project (`pynetappfoundry`) that generates typed Python from a YANG schema and has an
+ADR (ADR-0008) documenting a round-trip invariant. **This example is illustrative only** — actual
+instruction files belong in downstream repos, not in this template.
+
+```
+---
+applyTo: 'src/**/*.py'
+---
+Skill: codegen
+
+Self-check before committing generated code:
+1. Run `make roundtrip` and confirm exit 0 — the generated types must deserialize
+   what the serializer produces without loss (ADR-0008).
+2. Confirm no hand-edited lines remain in `src/generated/` — regenerate from schema
+   if any exist.
+3. Confirm the schema version in `src/generated/_version.py` matches the YANG source
+   revision header.
+
+Observed failures: endavis/pynetappfoundry#104, endavis/pynetappfoundry#117
+```
+
+## Shared discipline across CLIs
+
+The **discipline** (≤30 lines, numbered self-checks, observed-failures footer) is shared across
+Claude Code, Gemini CLI, and GitHub Copilot even though the file format differs:
+
+| CLI | Directory | Load mechanism |
+| :--- | :--- | :--- |
+| Claude Code | `.claude/rules/` | `@./rules/*.md` in `.claude/CLAUDE.md` |
+| Gemini CLI | `.gemini/rules/` | One `@./.gemini/rules/<name>.md` line per rule file in `GEMINI.md` (literal paths only) |
+| GitHub Copilot | `.github/instructions/` | Native auto-discovery (no directive needed) |
+
+See [`.claude/rules/README.md`](../../.claude/rules/README.md) and
+[`.gemini/rules/README.md`](../../.gemini/rules/README.md) for the Claude and Gemini variants.
+
+## What NOT to put in an instruction file
+
+- **Broad workflow rules** — things like "never commit to main" or "always run `doit check`"
+  belong in `AGENTS.md`, not here. Instruction files are for stack-specific self-checks, not
+  universal workflow.
+- **Generic best-practices** — "prefer composition over inheritance", "write type annotations" —
+  these are noise. They drift into checklists the model satisfies by rote without changing
+  behavior.
+- **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule
+  was violated, the instruction file is not ready to be written.

--- a/docs/decisions/9006-merge-gate-workflow.md
+++ b/docs/decisions/9006-merge-gate-workflow.md
@@ -20,6 +20,7 @@ PRs could be merged while CI was still running or without explicit human approva
 - Issue #154: Fix merge-gate to wait for CI completion before allowing merge
 - Issue #168: Add Python 3.14 to CI testing matrix (changed ready-to-merge to pure gate)
 - Issue #428: Use GitHub App token for label application so Merge Gate re-runs on auto-applied labels
+- Issue #574: Add `ALLOW_AI_READY_TO_MERGE` env-var opt-in so humans can grant AI a session-scoped pass to apply the label
 
 ## Related Documentation
 

--- a/docs/decisions/9009-use-pre-commit-hooks-for-quality-gates.md
+++ b/docs/decisions/9009-use-pre-commit-hooks-for-quality-gates.md
@@ -18,6 +18,7 @@ Ensures bad code never enters the repository, provides fast feedback loop (secon
 - Issue #128: Align pre-commit, CI, and doit check to use consistent checks
 - Issue #19: Fix resolve pre-commit hook failures in template files
 - Issue #415: Add actionlint hook for GitHub Actions workflow validation
+- Issue #556: Validate uv.lock consistency on pyproject.toml changes
 
 ## Related Documentation
 

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -23,9 +23,9 @@ This template is designed primarily for **Claude Code**, which is the only agent
 | Agent | Permission model | Hooks support | Slash commands | LSP | Dual-agent role |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | **Codex CLI** | TOML approval policies (`.codex/config.toml`) plus repo skills (`.agents/skills/`) | Project-level `tools/hooks/ai/` apply via Codex hooks | Built-in only; repo workflow uses skills | Not documented | Standalone alternative (not part of dual-agent flow) |
-| **Gemini CLI** | JSON allowlists + lifecycle hooks (`.gemini/settings.json`) | Project-level hooks apply; Gemini lifecycle hooks supported | 5 (`/plan-issue`, `/implement`, `/finalize` standalone; `/plan-issue-stdout`, `/review-pr` orchestration-only) | Not documented | Standalone alternative; second-opinion reviewer / planner in dual-agent flow |
-| **GitHub Copilot CLI** | JSON hook config (`.github/hooks/copilot-hooks.json`) | Project-level hooks apply; Copilot `preToolUse` hook wired | Auto-discovers from `.claude/commands/` | Not documented | Standalone alternative (auto-discovers Claude commands) |
-| **Claude Code** | Layered permissions (`.claude/settings.local.json` + `.claude/settings.json` PreToolUse hooks) | Project-level hooks plus Claude PreToolUse hooks | 8 (`plan-issue`, `implement`, `finalize`, `close-issue`, `plan-both`, `review-both`, `gemini-review`, `where-am-i`) | Supported | Primary orchestrator in single-agent and dual-agent flows |
+| **Gemini CLI** | JSON allowlists + lifecycle hooks (`.gemini/settings.json`) | Project-level hooks apply; Gemini lifecycle hooks supported | 4 self-action (`/gemini:plan`, `/gemini:implement`, `/gemini:review`, `/gemini:adversarial-review`) + `/ghi-finalize` + 3 multi-orchestrator (`/multi-plan`, `/multi-review`, `/multi-adversarial-review`) + 12 delegation commands (`.gemini/commands/<target>/`) | Not documented | Standalone alternative; second-opinion reviewer / planner in multi-agent flow |
+| **GitHub Copilot CLI** | JSON hook config (`.github/hooks/copilot-hooks.json`) | Project-level hooks apply; Copilot `preToolUse` hook wired | 4 self-action (`/copilot-plan`, `/copilot-implement`, `/copilot-review`, `/copilot-adversarial-review`) and 12 cross-agent bridges (`/{claude,codex,gemini}-{plan,implement,review,adversarial-review}`) — all under `.github/skills/<target>-<action>/SKILL.md` (Copilot-only path, invisible to Claude). Copilot uses hyphen naming because skill names cannot contain colons. `/ghi-finalize` and `/multi-*` come from `.agents/skills/` | Not documented | Standalone alternative |
+| **Claude Code** | Layered permissions (`.claude/settings.local.json` + `.claude/settings.json` PreToolUse hooks) | Project-level hooks plus Claude PreToolUse hooks | 4 self-action (`/claude:plan`, `/claude:implement`, `/claude:review`, `/claude:adversarial-review`) + `/ghi-finalize`, `/ghi-status` + 3 multi-orchestrator (`/multi-plan`, `/multi-review`, `/multi-adversarial-review`) + 12 delegation commands (`.claude/commands/<target>/`) | Supported | Primary orchestrator in single-agent and multi-agent flows |
 
 The project-level dangerous-command hooks under `tools/hooks/ai/` apply to all four agents regardless of per-agent config and cannot be bypassed by editing `.claude/settings.local.json`, `.codex/config.toml`, `.gemini/settings.json`, or `.github/hooks/copilot-hooks.json`. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
 
@@ -60,7 +60,7 @@ codex
 - [Configuring Codex](https://developers.openai.com/codex/local-config/)
 - [Codex Security Guide](https://developers.openai.com/codex/security/)
 
-**Codex parity status:** Codex does not use repo-defined slash commands in this template. Instead, it uses repo-scoped workflow skills checked into `.agents/skills/` and invoked through Codex's built-in skill surface such as `/skills` or explicit mentions like `$codex-plan`, `$codex-implement`, and `$ghi-finalize`. LSP integration is not documented for Codex here. Codex works as a standalone alternative for contributors who prefer the OpenAI CLI. The shared dangerous-command hook at `tools/hooks/ai/block-dangerous-commands.py` applies to Codex via `.codex/config.toml`, and the approval-policy rules remain a secondary defense layer. For the broader workflow picture, see [Slash Commands and Workflows](ai/slash-commands.md).
+**Codex parity status:** Codex does not use repo-defined slash commands in this template. Instead, it uses repo-scoped workflow skills checked into `.agents/skills/` and invoked through Codex's built-in skill surface such as `/skills` or explicit mentions like `$codex-plan`, `$codex-implement`, `$codex-review`, `$codex-adversarial-review`, and `$ghi-finalize`. LSP integration is not documented for Codex here. Codex works as a standalone alternative for contributors who prefer the OpenAI CLI. The shared dangerous-command hook at `tools/hooks/ai/block-dangerous-commands.py` applies to Codex via `.codex/config.toml`, and the approval-policy rules remain a secondary defense layer. For the broader workflow picture, see [Slash Commands and Workflows](ai/slash-commands.md).
 
 ### 2. Gemini CLI (Google)
 
@@ -79,6 +79,14 @@ Gemini CLI can read `AGENTS.md` (or `GEMINI.md`) from the project root. The conf
 - `ShellTool` - Execute shell commands
 - `ReadFileTool`, `WriteFileTool` - File operations
 - `LSTool`, `GrepTool` - File exploration
+
+#### Token Efficiency
+
+`.gemini/settings.json` ships with a compression default aimed at token efficiency in long sessions, mirroring the Claude tuning:
+
+| Setting | Value | Effect | Rationale |
+| :--- | :--- | :--- | :--- |
+| `chatCompression.contextPercentageThreshold` | `0.5` | Compression triggers at 50% of context window usage. | Reclaims token space earlier to avoid hitting hard context limits in long sessions. |
 
 **Setup:**
 ```bash
@@ -155,13 +163,53 @@ claude
 
 For complete setup instructions and troubleshooting, see `.claude/lsp-setup.md` in the repository root.
 
+#### Environment Variables
+
+`.claude/settings.json` ships an `env` block with three Claude Code defaults aimed at token efficiency and session survival on long-running work. These propagate to downstream consumers via the template-sync mechanism, so all projects derived from this template inherit the same defaults.
+
+| Var | Value | Effect | Risk |
+| :--- | :--- | :--- | :--- |
+| `ENABLE_PROMPT_CACHING_1H` | `1` | Extends prompt cache TTL from 5 minutes to 1 hour. Cuts cost on repeated reads of the same context within a session. | None — pure efficiency flag. |
+| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | `50` | Auto-compaction triggers at 50% of the context window instead of the default (~92%). Sessions compact earlier, leaving more headroom for the post-compact continuation. | More frequent compaction churn; mitigated by the [PreCompact handoff hook](ai/auto-checkpoint-hook.md) which preserves context across compaction events. |
+| `CLAUDE_CODE_SUBAGENT_MODEL` | `claude-sonnet-4-6` | Subagents (e.g. those spawned by `/claude:implement`) default to Sonnet 4.6 instead of inheriting the parent's Opus model. | Subagent output quality drops below Opus on hard reasoning tasks. Mitigate per-agent (see below). |
+
+**Per-agent model overrides:**
+
+`CLAUDE_CODE_SUBAGENT_MODEL` is a default. Any agent file under `.claude/agents/` that declares an explicit `model:` in its YAML frontmatter wins:
+
+```yaml
+---
+name: high-stakes-reviewer
+model: claude-opus-4-7   # overrides the env-var default for this agent only
+---
+```
+
+Agents without a `model:` line inherit the env-var default. This template's `.claude/agents/implement-worker.md` deliberately does not override — implement-worker runs on Sonnet 4.6 as an explicit cost/quality trade-off. Future high-stakes subagents (e.g. design review, security review) can opt into Opus on a per-file basis.
+
+**Per-developer overrides:**
+
+To opt out or tune values for your local environment, override them in `.claude/settings.local.json` (already gitignored, used elsewhere in this template for personal config). Example:
+
+```json
+{
+  "env": {
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "75"
+  }
+}
+```
+
+**Cross-references:**
+
+- The 50% autocompact threshold is paired with the [PreCompact handoff hook](ai/auto-checkpoint-hook.md) — earlier compaction has lower cost because the hook preserves context across compaction events automatically.
+- For operators who need more aggressive token reduction, see [AI Agent Token-Efficiency Add-Ons](ai/token-efficiency-add-ons.md) — a catalogue of opt-in external tools (RTK, Headroom, Caveman) with tipping-point guidance and trust caveats.
+
 ### 4. GitHub Copilot CLI
 
 **Configuration:** `.copilot/` directory
 
 > **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
 
-GitHub Copilot CLI reads `AGENTS.md` directly and auto-discovers project skills from `.claude/commands/`, so the full slash-command workflow (`/plan-issue`, `/implement`, `/finalize`, `/close-issue`, `/where-am-i`, etc.) is available in Copilot sessions without any parallel command files. The `implement-worker` subagent used by `/implement` is shared with Claude (defined in `.claude/agents/implement-worker.md`).
+GitHub Copilot CLI reads `AGENTS.md` directly and discovers project skills from `skills/` directories — `.github/skills/`, `.agents/skills/`, and `.claude/skills/` (per `@github/copilot` SDK `sdk/index.d.ts`). It does **not** read any `commands/` directory. Self-action and cross-agent bridge skills (`/copilot-plan`, `/copilot-implement`, `/copilot-review`, `/copilot-adversarial-review`, and the 12 cross-agent bridges `/<target>-<action>`) live under `.github/skills/<target>-<action>/SKILL.md`. The `.github/skills/` location is chosen specifically because it's the only Copilot project skill path that Claude does **not** also read — placing bridges there avoids duplicating slash commands in Claude. Hyphen naming is structural — skill names are derived from directory names and cannot contain colons. Copilot also natively discovers per-stack instruction files from `.github/instructions/*.instructions.md`; see [`.github/instructions/README.md`](../../.github/instructions/README.md) for the scaffold and format.
 
 **Hook wiring:**
 
@@ -192,14 +240,17 @@ copilot
 **Files:**
 - `.copilot/README.md` - Description of the Copilot CLI config directory
 - `.github/hooks/copilot-hooks.json` - `preToolUse` hook wiring
-- `.claude/commands/*.md` - Slash commands (auto-discovered by Copilot CLI)
-- `.claude/agents/implement-worker.md` - Shared subagent definition
+- `.github/instructions/*.instructions.md` - Copilot-native per-stack instruction files (auto-discovered)
+- `.github/instructions/README.md` - Instruction-file scaffold and format reference
+- `.github/skills/<target>-<action>/SKILL.md` — Copilot-host workflow skills (16 files: 4 self-action + 12 cross-agent bridges; placed under `.github/skills/` so Claude does not also surface them)
+- `.agents/skills/` — interoperable Codex skill path, also read by Copilot (provides `/ghi-finalize`, `/ghi-status`, `/multi-*`)
+- `.claude/agents/implement-worker.md` — Shared subagent definition
 
 **Documentation:**
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli)
 - [Copilot CLI Hooks](https://docs.github.com/en/copilot/how-tos/use-copilot-for-common-tasks/use-copilot-in-the-cli)
 
-**Copilot parity status:** Copilot CLI ships no parallel command or agent files — it auto-discovers from `.claude/commands/` and `.claude/agents/`, so every Claude slash command works unchanged in Copilot sessions. Copilot is not part of the dual-agent workflow (Claude and Gemini are); it works as a standalone alternative for contributors who prefer GitHub Copilot. The project-level hooks under `tools/hooks/ai/` apply to Copilot via `.github/hooks/copilot-hooks.json` — see [Command Blocking](ai/command-blocking.md). For the broader slash-command picture, see [Slash Commands and Workflows](ai/slash-commands.md).
+**Copilot parity status:** Copilot CLI exposes 16 cross-agent matrix cells under `.github/skills/<target>-<action>/SKILL.md` — 4 self-action skills (`/copilot-plan`, `/copilot-implement`, `/copilot-review`, `/copilot-adversarial-review`) plus 12 cross-agent bridges (`/{claude,codex,gemini}-{plan,implement,review,adversarial-review}`). The bridge bodies cannot be shared with Claude or Gemini because each target CLI requires a different invocation (`claude -p`, `codex -a never exec`, `gemini -y -p`). The other workflow skills (`/ghi-finalize`, `/ghi-status`, `/multi-*`) come from `.agents/skills/`. The `.github/skills/` location was chosen because it's the only Copilot project skill path that Claude does not also read — bridges there do not surface as duplicate slash commands in Claude. Hyphen naming is a structural constraint (skill names cannot contain colons), not a stylistic choice. The project-level hooks under `tools/hooks/ai/` apply to Copilot via `.github/hooks/copilot-hooks.json` — see [Command Blocking](ai/command-blocking.md). For the broader slash-command picture, see [Slash Commands and Workflows](ai/slash-commands.md).
 
 ### 5. Other AI Tools
 
@@ -236,7 +287,7 @@ This template ships several files that influence agent behavior. They fall into 
 - **`AGENTS.md`** (project root, ~20 KB) — universal source of truth for architecture, workflow, tooling hierarchy, and security rules. Read directly by Codex CLI, Gemini CLI, and GitHub Copilot CLI; imported by Claude Code via `@../AGENTS.md` in `.claude/CLAUDE.md`.
 - **`.claude/CLAUDE.md`** (~2 KB) — Claude-specific complement. First line is `@../AGENTS.md`, which imports the universal rules; the rest adds Claude-specific layers (token-efficiency guidance, the mandatory TodoWrite plan-test-code loop, the development workflow reminder, and the commit workflow reminder).
 - **`GEMINI.md`** (project root, ~1 KB) — Gemini-specific complement. Covers Gemini's stdout-only collaboration mode (so Claude handles GitHub writes), the output signing footer, and Gemini's tool-usage rules. Read alongside `AGENTS.md` by Gemini CLI, not instead of it.
-- **`.copilot/README.md`** — describes the Copilot CLI config directory. Copilot CLI reads `AGENTS.md` directly and auto-discovers slash commands from `.claude/commands/`; no Copilot-specific context markdown is required.
+- **`.copilot/README.md`** — describes the Copilot CLI config directory. Copilot CLI reads `AGENTS.md` directly, auto-discovers slash commands from `.claude/commands/`, and uses `.github/instructions/*.instructions.md` for Copilot-native per-stack instruction files.
 - **`.codex/config.toml`** — Codex approval policy file (TOML). Not a context file; configures permissions only. Codex reads `AGENTS.md` directly for instructions.
 - **`.claude/settings.json`** — Claude PreToolUse hooks and statusline configuration. Committed.
 - **`.claude/settings.local.json`** — local Claude permissions overlay. Not committed.
@@ -399,7 +450,8 @@ gemini --yolo
 
 **`.copilot/` auto-detection:**
 - The `.copilot/` directory exists primarily to document Copilot-specific wiring; Copilot CLI does not require any config files there
-- If you move the repository, Copilot CLI still loads `AGENTS.md` from the repo root and the hook from `.github/hooks/copilot-hooks.json`
+- Copilot CLI also auto-discovers `.github/instructions/*.instructions.md` without any import or directive
+- If you move the repository, Copilot CLI still loads `AGENTS.md` from the repo root, the hook from `.github/hooks/copilot-hooks.json`, and instruction files from `.github/instructions/`
 
 ## Resources
 

--- a/docs/development/ai/auto-checkpoint-hook.md
+++ b/docs/development/ai/auto-checkpoint-hook.md
@@ -1,0 +1,173 @@
+---
+title: Auto-Checkpoint and Session-Restore Hooks
+description: PreCompact and SessionStart hooks that preserve context across autocompact events
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - hooks
+  - checkpoint
+---
+
+# Auto-Checkpoint and Session-Restore Hooks
+
+Two Claude Code hooks that wire the existing `/checkpoint` and `/restore` primitives into the
+`PreCompact` and `SessionStart` lifecycle events, so context is preserved automatically when
+autocompact fires mid-task — no human in the loop required.
+
+## What They Do
+
+### PreCompact hook (`precompact-checkpoint.py`)
+
+Before Claude Code compacts the conversation context, the hook:
+
+1. Reads the `transcript_path` from the hook payload.
+2. Takes up to 200 KB from the tail of the JSONL transcript.
+3. Spawns `claude -p --bare --model claude-sonnet-4-6` with a strict-JSON prompt asking for:
+   `{title, status, in_flight_work, constraints, files_touched, next_steps, resume_prompt}`.
+4. Parses the JSON response and renders it into a markdown checkpoint file matching the
+   `/checkpoint` section structure (Title, Status, In-flight work, Constraints, Files touched,
+   Next steps, Resume prompt).
+5. Writes the file to `tmp/checkpoints/{inv_epoch}-auto-precompact.md` where `inv_epoch` is a
+   10-digit decreasing integer (newest sorts first under default `ls`).
+6. On any failure (timeout, missing CLI, non-zero exit, JSON parse error, missing transcript),
+   falls back to a banner + raw transcript tail tagged `AUTO_PARTIAL`.
+7. Always exits 0 — the hook never blocks the compaction event.
+
+### SessionStart hook (`session-resume-restore.py`)
+
+When Claude Code starts a session whose trigger contains "compact" or "resume":
+
+1. Globs `tmp/checkpoints/*-auto-precompact*.md` and picks the lexically smallest file
+   (newest by `inv_epoch` convention).
+2. Reads the file and emits it as `hookSpecificOutput.additionalContext` so the model sees
+   the checkpoint body as injected context at session start.
+3. If no matching file exists, no-ops silently.
+4. Always exits 0.
+
+## Filename Convention
+
+Auto-checkpoint filenames follow the same `{inv_epoch}-{slug}.md` convention as manual
+`/checkpoint` files:
+
+```
+tmp/checkpoints/9999999999-auto-precompact.md
+```
+
+The `inv_epoch` is computed as `9999999999 - int(time.time())`, matching Step 1 of
+`.claude/commands/checkpoint.md` exactly. On same-second collision (rare), a single letter
+suffix is appended: `…-auto-precompact-a.md`, `…-auto-precompact-b.md`, etc.
+
+Because the convention is shared, manual `/restore` can also load auto-precompact files
+by slug: `/restore auto-precompact`.
+
+## Opt-Out and Widening
+
+| Env var | Effect |
+|---|---|
+| `CLAUDE_NO_AUTO_RESTORE=1` | SessionStart hook no-ops even when checkpoints exist |
+| `CLAUDE_RESTORE_ANY=1` | SessionStart hook widens glob to `*.md`, restoring any checkpoint (not just auto-precompact ones) |
+
+Set these in `.claude/settings.local.json` (gitignored) or in your shell profile:
+
+```json
+{
+  "env": {
+    "CLAUDE_NO_AUTO_RESTORE": "1"
+  }
+}
+```
+
+## Synthesis Prompt Shape
+
+The PreCompact hook sends a structured prompt requesting strict JSON output:
+
+```
+{title, status, in_flight_work, constraints, files_touched (array),
+ next_steps, resume_prompt}
+```
+
+If the model wraps the JSON in markdown fences, the hook strips them before parsing.
+On any parse failure, the hook falls back to `AUTO_PARTIAL` mode (raw transcript tail).
+
+## Fallback Behavior
+
+| Condition | Result |
+|---|---|
+| Synthesis succeeds, JSON valid | Full structured checkpoint written |
+| Synthesis returns non-zero exit | `AUTO_PARTIAL` fallback written |
+| `claude` CLI not found (`FileNotFoundError`) | `AUTO_PARTIAL` fallback written |
+| Synthesis times out (90 s) | `AUTO_PARTIAL` fallback written |
+| JSON parse fails | `AUTO_PARTIAL` fallback written |
+| Transcript file missing | `AUTO_PARTIAL` fallback written (empty tail) |
+| Malformed stdin JSON | Exits 0, no file written |
+
+`AUTO_PARTIAL` files are tagged in their title so you can identify them and know the
+structured fields are absent.
+
+## Settings Wiring
+
+`.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "timeout": 90,
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/precompact-checkpoint.py"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/session-resume-restore.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The `timeout: 90` on `PreCompact` matches the synthesis subprocess timeout so the hook
+does not hang indefinitely if the CLI is slow to respond.
+
+## Manual Verification
+
+These steps cannot be run by a subagent but are provided for contributor verification:
+
+1. Start a long session; run `/compact` to force a `PreCompact` event. Confirm a new file
+   appears in `tmp/checkpoints/` with the `-auto-precompact.md` suffix.
+2. Read the file. Confirm it has the expected sections — not just an `AUTO_PARTIAL` dump.
+3. Start a fresh session via `claude --resume`. Confirm the checkpoint body appears inlined
+   in the new session's initial context.
+4. Set `CLAUDE_NO_AUTO_RESTORE=1`, repeat step 3; confirm no inlining.
+5. Force a synthesis failure (temporarily rename `claude` on PATH); repeat step 1; confirm
+   the `AUTO_PARTIAL` fallback file is produced.
+
+## Files
+
+| File | Description |
+|---|---|
+| [`tools/hooks/ai/precompact-checkpoint.py`](../../../tools/hooks/ai/precompact-checkpoint.py) | PreCompact hook script |
+| [`tools/hooks/ai/session-resume-restore.py`](../../../tools/hooks/ai/session-resume-restore.py) | SessionStart hook script |
+| [`tests/test_hook_precompact_checkpoint.py`](../../../tests/test_hook_precompact_checkpoint.py) | Pytest coverage for PreCompact hook |
+| [`tests/test_hook_session_resume_restore.py`](../../../tests/test_hook_session_resume_restore.py) | Pytest coverage for SessionStart hook |
+| [`.claude/settings.json`](../../../.claude/settings.json) | Wires both hooks into the lifecycle |
+
+## Related
+
+- [AI Command Blocking](command-blocking.md) — sibling `PreToolUse` hook for dangerous commands
+- [Ruff Auto-Fix on Edit](ruff-fix-hook.md) — sibling `PostToolUse` hook for Python formatting
+- [Slash Commands and Workflows](slash-commands.md) — the `/checkpoint` and `/restore` manual commands
+- [AGENTS.md](../../../AGENTS.md) — `tmp/checkpoints/` convention and cross-agent portability

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -98,6 +98,15 @@ EOF
             "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/block-dangerous-commands.py"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/block-dangerous-commands.py"
+          }
+        ]
       }
     ]
   }
@@ -110,10 +119,18 @@ EOF
 ```json
 {
   "hooks": {
-    "enabled" : true,
     "BeforeTool": [
       {
         "matcher": "run_shell_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $GEMINI_PROJECT_DIR/tools/hooks/ai/block-dangerous-commands.py"
+          }
+        ]
+      },
+      {
+        "matcher": "write_file|replace",
         "hooks": [
           {
             "type": "command",
@@ -125,6 +142,8 @@ EOF
   }
 }
 ```
+
+Gemini's file-write tools are `write_file` (full-file overwrite, `content` param) and `replace` (string replacement, `old_string`/`new_string` params). Both use `file_path`.
 
 #### Copilot CLI
 
@@ -145,6 +164,8 @@ EOF
 }
 ```
 
+No change needed for Copilot — the hook fires on every tool call (no `matcher` field), so Edit/Write variants are automatically covered.
+
 #### Codex CLI
 
 `.codex/config.toml`:
@@ -162,6 +183,15 @@ type = "command"
 command = 'python3 "$(git rev-parse --show-toplevel)/tools/hooks/ai/block-dangerous-commands.py"'
 timeout = 30
 statusMessage = "Checking Bash command"
+
+[[hooks.PreToolUse]]
+matcher = "^(Edit|Write|MultiEdit)$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = 'python3 "$(git rev-parse --show-toplevel)/tools/hooks/ai/block-dangerous-commands.py"'
+timeout = 30
+statusMessage = "Checking file edit"
 ```
 
 Codex uses the shared hook as the primary defense layer. Project docs should not rely on the obsolete `[[approval_policy]]` command-rule format.
@@ -244,6 +274,58 @@ Some labels are governance controls that require human approval. AI agents are b
 |-------|--------|
 | `ready-to-merge` | Signals human approval that PR is ready for merge. Add manually via `gh pr edit --add-label ready-to-merge` or GitHub web UI. |
 
+##### Opt-in: `ALLOW_AI_READY_TO_MERGE`
+
+A human can grant an AI agent a one-session pass to apply the `ready-to-merge` label by setting an environment variable **before launching the AI CLI**:
+
+```bash
+export ALLOW_AI_READY_TO_MERGE=1
+claude  # or gemini, copilot, codex
+```
+
+The hook reads `os.environ` at hook-startup time (the AI CLI's process environment), so the variable must be set in the shell that launches the AI process — not by any command the AI itself runs. The AI has no path to set or persist this variable; attempts to do so are blocked (see [Env-Var Persistence Blocks](#env-var-persistence-blocks) below).
+
+**Truthy values** (case-insensitive): `1`, `true`, `yes`, `on`. All other values (including empty string or unset) are falsy and preserve the block.
+
+**Threat model:**
+
+- The AI cannot set the variable in `os.environ` of its own parent process.
+- The AI cannot persist the variable by writing to shell rc files, `.envrc`, `.env`, or AI CLI settings files — the hook blocks those writes.
+- Each AI CLI session inherits a fixed snapshot of the environment; a Bash subprocess setting the variable does not affect the hook's already-read `os.environ`.
+- The variable is scoped to a single shell session. Close the terminal (or `unset ALLOW_AI_READY_TO_MERGE`) to revoke the pass.
+
+**To disable:** run `unset ALLOW_AI_READY_TO_MERGE`, or close the shell, or restart the AI CLI without the variable set.
+
+#### Env-Var Persistence Blocks
+
+The hook fires on **Edit**, **Write**, and **MultiEdit** (Claude/Codex) and **write_file**/**replace** (Gemini) in addition to Bash commands. Any operation whose payload contains the literal string `ALLOW_AI_READY_TO_MERGE` **and** whose target is a known persistence file is blocked.
+
+**Protected file basenames** (Bash redirect target or `file_path` argument):
+
+| File | Notes |
+|------|-------|
+| `.bashrc`, `.zshrc`, `.profile`, `.bash_profile`, `.bash_login`, `.zshenv` | Shell init files |
+| `config.fish` | Only when parent path contains `.config/fish` |
+| `.envrc`, `.env`, `.env.local`, `.env.development`, `.env.production` | Project env files |
+| `settings.json`, `settings.local.json` | Only when parent dir is `.claude`, `.gemini`, or `.copilot` |
+| `config.toml` | Only when parent dir is `.codex` |
+| `copilot-hooks.json` | Any path (Copilot's env-injection vector) |
+
+**Example blocked Bash command:**
+
+```bash
+# BLOCKED — AI cannot persist the variable via shell redirect
+echo "export ALLOW_AI_READY_TO_MERGE=1" >> ~/.bashrc
+```
+
+**Example blocked file edit:**
+
+```
+# BLOCKED — AI cannot persist the variable via Edit tool
+Edit ~/.bashrc
+  new_string: "export ALLOW_AI_READY_TO_MERGE=1"
+```
+
 ### Adding New Patterns
 
 Edit `tools/hooks/ai/block-dangerous-commands.py`:
@@ -272,3 +354,4 @@ Then run the test suite to verify.
 - [AI Enforcement Principles](enforcement-principles.md) - Why and how we enforce rules in code
 - [AGENTS.md](../../../AGENTS.md) - AI agent rules including "When Blocked Protocol"
 - [AI Agent Setup](../AI_SETUP.md) - Setting up AI coding assistants
+- [Bash raw-tool ban](token-efficiency-add-ons.md#bash-raw-tool-ban-opt-in) - Opt-in hook that blocks raw shell commands AI agents should use native tools for (`cat`, `head`, `tail`, `find`, `grep`, `rg`, `wc`)

--- a/docs/development/ai/first-5-minutes.md
+++ b/docs/development/ai/first-5-minutes.md
@@ -31,7 +31,7 @@ The rest of this page assumes you have these working.
 
 Launch Claude Code from the repository root. On startup Claude automatically loads `AGENTS.md` (workflow and conventions), `.claude/CLAUDE.md` (Claude-specific rules on top of `AGENTS.md`), and the project hooks under `tools/hooks/ai/` (which block dangerous commands for every agent, not just Claude). You do not need to paste any context — the template is designed so a fresh session already knows the rules.
 
-If you are not sure what state you are in, run `/where-am-i` at any time. It inspects the branch, issue state, plan comments, uncommitted changes, unpushed commits, and open PRs, then reports a summary and suggests the next command. It is read-only and safe to run whenever you are unsure.
+If you are not sure what state you are in, run `/ghi-status` at any time (Claude) or the equivalent for your agent. It inspects the branch, issue state, plan comments, uncommitted changes, unpushed commits, and open PRs, then reports a summary and suggests the next command. It is read-only and safe to run whenever you are unsure.
 
 ### 2. Pick an issue
 
@@ -39,9 +39,9 @@ Every change starts from an issue. Either list the open backlog with `gh issue l
 
 For the rest of this walkthrough assume you have picked issue number `42`.
 
-### 3. `/plan-issue 42`
+### 3. `/claude:plan 42`
 
-Run `/plan-issue 42` in the main conversation. Claude enters plan mode, reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches the issue, explores the codebase, and drafts a plan. Plan mode is interactive: Claude will ask questions and iterate with you until you approve the plan. Only on approval does it exit plan mode and post the plan as a comment on the issue with the header `## Implementation Plan for #42: <title>`. That posted comment is the artifact the next command reads.
+Run `/claude:plan 42` in the main conversation. Claude enters plan mode, reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches the issue, explores the codebase, and drafts a plan. Plan mode is interactive: Claude will ask questions and iterate with you until you approve the plan. Only on approval does it exit plan mode and post the plan as a comment on the issue with the header `## Implementation Plan for #42: <title>`. That posted comment is the artifact the next command reads.
 
 What you'll see (illustrative — your plan will look different):
 
@@ -66,21 +66,21 @@ The provider module currently makes a network call on every lookup...
 - `doit check` passes
 ```
 
-Read the comment, discuss revisions in chat if anything is off, and re-run `/plan-issue 42` if you need a fresh pass.
+Read the comment, discuss revisions in chat if anything is off, and re-run `/claude:plan 42` if you need a fresh pass.
 
-### 4. `/implement 42`
+### 4. `/claude:implement 42`
 
-Once the plan comment exists, run `/implement 42`. Claude checks out `main`, pulls, and creates a branch whose type is derived from the issue's labels — for example, a `feature` issue becomes `feat/42-add-caching-layer`. Claude then spawns a subagent via the Task tool. The subagent does the heavy work: re-reads `AGENTS.md`, fetches the plan via `gh api`, creates files, writes tests, and runs `doit check`, fixing failures rather than giving up. The main conversation context receives only the subagent's summary, which keeps your scrollback clean and your context window small.
+Once the plan comment exists, run `/claude:implement 42`. Claude checks out `main`, pulls, and creates a branch whose type is derived from the issue's labels — for example, a `feature` issue becomes `feat/42-add-caching-layer`. Claude then spawns a subagent via the Task tool. The subagent does the heavy work: re-reads `AGENTS.md`, fetches the plan via `gh api`, creates files, writes tests, and runs `doit check`, fixing failures rather than giving up. The main conversation context receives only the subagent's summary, which keeps your scrollback clean and your context window small.
 
 The artifact at the end of this step is an uncommitted working tree on the feature branch. Nothing has been committed yet — that is deliberate.
 
-### 5. (Optional) `/gemini-review`
+### 5. (Optional) `/multi-review claude gemini`
 
-If you have the Gemini CLI installed and want a second opinion on the changes, you can run `/gemini-review` at this point (after a PR exists) or use `/review-both` for a parallel Claude + Gemini review. The template invokes Gemini in an isolated context, captures its stdout, and posts it as a comment on the PR. Gemini never writes to GitHub directly — the orchestrating Claude agent does the posting. Skip this step if you are running single-agent.
+If you have the Gemini CLI installed and want a second opinion on the changes, you can run `/multi-review claude gemini` at this point (after a PR exists). This runs both agents in isolated contexts, posts each review as a separate PR comment, and then synthesizes the findings for you to approve before posting. If you want an adversarial challenge instead of a code review, use `/multi-adversarial-review claude gemini`. Skip this step if you are running single-agent.
 
-### 6. `/finalize`
+### 6. `/ghi-finalize`
 
-Run `/finalize` when you are satisfied with the changes. Claude detects the branch and issue number, spawns a finalization subagent that reviews changed files for doc/ADR updates, runs `doit check` one more time, and drafts both a commit message and a PR body. The main conversation then presents the drafts to you and **waits for explicit approval** before staging files, committing, and running `doit pr`. Nothing gets committed without your go-ahead.
+Run `/ghi-finalize` when you are satisfied with the changes. Claude detects the branch and issue number, spawns a finalization subagent that reviews changed files for doc/ADR updates, runs `doit check` one more time, and drafts both a commit message and a PR body. The main conversation then presents the drafts to you and **waits for explicit approval** before staging files, committing, and running `doit pr`. Nothing gets committed without your go-ahead.
 
 What you'll see (illustrative — your drafts will look different):
 
@@ -118,9 +118,13 @@ Approve, and Claude stages the files, commits, and opens the PR via `doit pr`. T
 
 Merging is never automated. Review the PR yourself, wait for CI to go green, add the `ready-to-merge` label, and merge via `doit pr_merge` (or the GitHub web UI). The `ready-to-merge` label and the Merge Gate action are designed to be a human checkpoint — do not let an agent add that label for you.
 
-### 8. `/close-issue 42`
+### 8. Close the issue
 
-After the PR merges, run `/close-issue 42`. Claude verifies a merged PR references `#42`, updates the task checkboxes in the issue body, posts the closing comment `Addressed in PR #<pr-number>`, and closes the issue. It then scans the PR body and comments for related-issue references (`Addresses`, `Part of`, `Closes`, bare `#N`, and so on) and asks you, one at a time, whether to close each open related issue. It never closes a related issue without per-issue confirmation.
+After the PR merges, close the linked issue. The easiest path is to have merged with `doit pr_merge --auto-close`, which closes the issue and posts a closing comment in one step. If you merged via the web UI, close manually:
+
+```bash
+gh issue close 42 --comment "Addressed in PR #<pr-number>"
+```
 
 That is the full loop.
 
@@ -128,17 +132,17 @@ That is the full loop.
 
 Every step in the flow produces a specific artifact the next step expects:
 
-- `/plan-issue <n>` → a plan comment on the issue with the header `## Implementation Plan for #<n>`
-- `/implement <n>` → a feature branch with an uncommitted working tree
-- `/finalize` → a staged commit plus an open PR referencing `Addresses #<n>`
+- `/<currentai>:plan <n>` → a plan comment on the issue with the header `## Implementation Plan for #<n>`
+- `/<currentai>:implement <n>` → a feature branch with an uncommitted working tree
+- `/ghi-finalize` → a staged commit plus an open PR referencing `Addresses #<n>`
 - Merge → a merged commit on `main` and a closed PR
-- `/close-issue <n>` → a closed issue with updated checkboxes and a closing comment
+- `doit pr_merge --auto-close` (or `gh issue close`) → a closed issue with a closing comment
 
 Knowing the artifact chain is the fastest way to figure out where you are if you get interrupted mid-flow.
 
 ## If you get lost
 
-Run `/where-am-i`. It is read-only, has no side effects, and will tell you the current branch, issue state, plan comment status, uncommitted changes, unpushed commits, open PRs, and the suggested next command. Run it any time you are unsure. For the full command-by-command reference and the dual-agent variants, see [Slash Commands and Workflows](slash-commands.md).
+Run `/ghi-status`. It is read-only, has no side effects, and will tell you the current branch, issue state, plan comment status, uncommitted changes, unpushed commits, open PRs, and the suggested next command. Run it any time you are unsure. For the full command-by-command reference and the dual-agent variants, see [Slash Commands and Workflows](slash-commands.md).
 
 ## See also
 
@@ -146,5 +150,9 @@ Run `/where-am-i`. It is read-only, has no side effects, and will tell you the c
 - [AI Agent Setup](../AI_SETUP.md) — per-CLI configuration, permissions, and hooks.
 - [Architectural Conventions](architectural-conventions.md) — imperative rules for AI-generated code.
 - [AGENTS.md](../../../AGENTS.md) — universal context file and workflow reference.
+- [`.claude/rules/` scaffold](../../../.claude/rules/README.md) — per-stack rule-file pattern for Claude Code.
+- [`.gemini/rules/` scaffold](../../../.gemini/rules/README.md) — per-stack rule-file pattern for Gemini CLI.
+- [`.github/instructions/` scaffold](../../../.github/instructions/README.md) — per-stack instruction-file pattern for GitHub Copilot.
+- [`.agents/skills/` scaffold](../../../.agents/skills/README.md) — per-stack rule-shaped skill pattern for Codex CLI.
 - <!-- TODO: wire this link up properly when #342 lands -->
   For an end-to-end example of the *coding* side of a feature (creating a module, CLI subcommand, tests, and docs), see [the add-a-feature example](../../examples/add-a-feature.md) (tracked in [#342](https://github.com/endavis/pyproject-template/issues/342)).

--- a/docs/development/ai/lsp-tool.md
+++ b/docs/development/ai/lsp-tool.md
@@ -1,0 +1,116 @@
+---
+title: LSP Tool and Diagnostic Noise
+description: What the LSP tool gives an AI agent, why pyright diagnostics arrive stale, and the two opt-outs agents can flip on themselves
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - lsp
+  - pyright
+---
+
+# LSP Tool and Diagnostic Noise
+
+Claude Code (v2.0.74+) ships an `LSP` tool backed by the `pyright-lsp@claude-plugins-official` plugin. The tool itself is a navigation aid; the plugin layered on top of it is also responsible for a *separate* side channel that auto-injects pyright diagnostics into conversation context after edits. The two flows have very different cost profiles, and conflating them is what produces the "agent keeps chasing errors that aren't really errors" pattern.
+
+## What the `LSP` Tool Actually Exposes
+
+The `LSP` tool surfaces nine operations. **None of them return diagnostics.**
+
+| Operation | Use |
+|---|---|
+| `goToDefinition` | Jump to the file/line where a symbol is defined |
+| `findReferences` | Find every reference to a symbol across the workspace |
+| `hover` | Get the type signature and docstring at a position |
+| `documentSymbol` | List every symbol declared in a file |
+| `workspaceSymbol` | Search the entire workspace by symbol name |
+| `goToImplementation` | Jump from an interface/abstract member to its implementations |
+| `prepareCallHierarchy` | Anchor a call-hierarchy query at a position |
+| `incomingCalls` | List functions that call the anchored target |
+| `outgoingCalls` | List functions called by the anchored target |
+
+Every one of these answers from pyright's symbol index in milliseconds. The index is updated lazily but always responds with whatever it currently has. **Navigation is not where the slowness comes from.**
+
+## Where the Slow / Stale Errors Come From
+
+Diagnostics (type errors, lint warnings) are *not* an `LSP` tool operation. They reach the model through a separate side channel: the pyright-lsp plugin pushes pyright's `publishDiagnostics` output into conversation context after `Edit`/`Write` tool calls. This is the source of the noise:
+
+- **Stale diagnostics** — pyright re-analyzes the file (and its dependents) after every change. On a non-trivial graph this takes 1–4 seconds. The diagnostic snapshot is taken before re-analysis settles, so the model sees errors against line numbers that no longer exist or symbols that were just renamed. Tracked upstream as [anthropics/claude-code#17979](https://github.com/anthropics/claude-code/issues/17979) and [#21297](https://github.com/anthropics/claude-code/issues/21297).
+- **Hint-level noise promoted to errors** — pyright emits `DiagnosticTag.Unnecessary` (e.g., a never-used parameter) at *hint* severity. The plugin currently surfaces these as if they were diagnostics worth acting on. Tracked as [anthropics/claude-code#26634](https://github.com/anthropics/claude-code/issues/26634).
+
+mypy via `doit check` is the authoritative type checker for this repo. Pyright's role is purely to back the LSP tool — its diagnostics are advisory, and they are cheap to ignore by default.
+
+## Default Stance
+
+LSP stays on. The navigation operations are valuable, and the diagnostic noise is something an agent can tune out once it knows the shape of the problem (symptom: errors against line numbers that don't match the just-edited file; cure: re-read the file or run `doit check` rather than chase the diagnostic).
+
+If an agent (or the human running it) wants to silence the noise more aggressively, two opt-outs are below. Pick one or the other — running both is redundant.
+
+## Opt-Out A: Make Diagnostics Wait Until Pyright Catches Up
+
+Add a `PostToolUse` sleep hook to `.claude/settings.local.json` (gitignored, per-clone):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sleep 3",
+            "statusMessage": "Letting pyright catch up to prevent stale diagnostics"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+| | |
+|---|---|
+| **What it does** | Delays the next tool call by 3 seconds, giving pyright time to settle before the diagnostic snapshot fires. |
+| **Keeps diagnostics?** | Yes — the goal is fresher diagnostics, not fewer. |
+| **Cost** | ~3 s of pure wait per `Edit`/`Write`/`MultiEdit`. A 30-edit session pays ~90 s of dead time. |
+| **Caveats** | 1 s is often not enough on real codebases; 3 s is a safer floor but still won't survive a cold cache or a large refactor. The hook fires on every edit regardless of whether diagnostics would have been stale. Whether Claude Code reads diagnostics synchronously with PostToolUse return is undocumented — the hook is a community-known workaround, not a guaranteed fix. |
+| **Pick this when** | You actively use pyright's diagnostics and just want them to be correct. |
+
+## Opt-Out B: Turn Off Pyright Diagnostics Entirely
+
+Edit `pyproject.toml`:
+
+```toml
+[tool.pyright]
+typeCheckingMode = "off"   # was "basic"
+```
+
+| | |
+|---|---|
+| **What it does** | Pyright still indexes the workspace (so navigation works) but emits no type-check diagnostics, so there is nothing for the side channel to push into context. |
+| **Keeps diagnostics?** | No — pyright's diagnostics go silent. mypy via `doit check` remains authoritative. |
+| **Cost** | Zero runtime overhead. |
+| **Caveats** | You lose pyright's interactive view of type errors. If you were using pyright as a second opinion against mypy, you'd lose that signal until you flip it back. |
+| **Pick this when** | mypy via `doit check` is already your source of truth and pyright's running commentary is noise you'd rather not have. |
+
+## Future Direction
+
+Both [pyrefly (Meta)](https://pyrefly.org/) and [ty (Astral)](https://astral.sh/blog/ty) ship full LSP implementations backed by Rust analyzers, with re-analysis times measured in milliseconds rather than seconds. Either would collapse the staleness window enough that neither opt-out above would be necessary. Both are still beta as of May 2026; pyrefly is further along on Python typing conformance, ty is closer aligned with this repo's `uv`/`ruff` toolchain.
+
+A future migration would replace the `pyright-lsp@claude-plugins-official` plugin with a local plugin pointing `lspServers.<name>.command` at `pyrefly lsp` or `ty server`. No such plugin is in the official Claude Code marketplace yet; a local one is straightforward to author when the time is right.
+
+## Files
+
+| File | Description |
+|---|---|
+| [`.claude/lsp-setup.md`](../../../.claude/lsp-setup.md) | Earlier pyright-lsp installation notes (now partially superseded — LSP requests no longer hang) |
+| [`pyproject.toml`](../../../pyproject.toml) | `[tool.pyright]` block; flip `typeCheckingMode` here for opt-out B |
+| `.claude/settings.local.json` | Per-clone Claude settings; wire opt-out A here |
+
+## Related
+
+- [Ruff Auto-Fix on Edit Hook](ruff-fix-hook.md) — sibling `PostToolUse` hook that runs ruff `--fix` on edited Python files
+- [AI Command Blocking](command-blocking.md) — `PreToolUse` hook reference
+- [AI Architectural Conventions](architectural-conventions.md)

--- a/docs/development/ai/slash-commands.md
+++ b/docs/development/ai/slash-commands.md
@@ -22,81 +22,97 @@ This page documents the slash commands this template ships under `.claude/comman
 
 The default Claude flow takes an issue from unplanned to closed. Each step produces an artifact the next step expects.
 
-1. **`/plan-issue <n>`** — Claude enters plan mode in the main conversation, reads project rules, explores the codebase, drafts a plan, and iterates with the user until approved. On approval the plan is posted as a comment on issue `#n` with the header `## Implementation Plan for #<n>: <title>`. The next step expects this comment to exist.
-2. **User review of the plan** — read the comment, discuss revisions in chat, re-run `/plan-issue` if needed.
-3. **`/implement <n>`** — Claude verifies the plan comment exists, creates a branch (`<type>/<n>-<short-description>`) off fresh `main`, then spawns a subagent (Task tool) that reads `AGENTS.md`, fetches the plan, implements files and tests, and runs `doit check`. The main context receives only the summary. The artifact is an uncommitted working tree on the feature branch.
+1. **`/<currentai>:plan <n>`** (e.g. `/claude:plan <n>`) — the host agent enters plan mode in the main conversation, reads project rules, explores the codebase, drafts a plan, and iterates with the user until approved. On approval the plan is posted as a comment on issue `#n` with the header `## Implementation Plan for #<n>: <title>`. The next step expects this comment to exist.
+2. **User review of the plan** — read the comment, discuss revisions in chat, re-run `/<currentai>:plan` if needed.
+3. **`/<currentai>:implement <n>`** (e.g. `/claude:implement <n>`) — the host agent verifies the plan comment exists, creates a branch (`<type>/<n>-<short-description>`) off fresh `main`, then spawns a subagent (Task tool) that reads `AGENTS.md`, fetches the plan, implements files and tests, and runs `doit check`. The main context receives only the summary. The artifact is an uncommitted working tree on the feature branch.
 4. **User review of the changes** — inspect the diff and discuss fixes directly in chat; no command is needed for fix-ups.
-5. **`/finalize`** — Claude detects the branch and issue, spawns a finalization subagent that updates docs/ADRs as needed, runs `doit check`, and drafts a commit message and PR body. The main context presents the drafts and waits for explicit user approval before staging, committing, and creating the PR via `doit pr`. The artifact is an open PR referencing `Addresses #<n>`.
+5. **`/ghi-finalize`** — the host agent detects the branch and issue, spawns a finalization subagent that updates docs/ADRs as needed, runs `doit check`, and drafts a commit message and PR body. The main context presents the drafts and waits for explicit user approval before staging, committing, and creating the PR via `doit pr`. The artifact is an open PR referencing `Addresses #<n>`.
 6. **User-driven merge** — the user reviews the PR, adds the `ready-to-merge` label, and merges via `doit pr_merge` (or the web UI). This step is never automated.
-7. **`/close-issue <n>`** — Claude verifies a merged PR addresses `#n`, updates task checkboxes in the issue body, posts `Addressed in PR #<pr>`, closes the issue, and scans the PR for related issues to optionally close as well.
+7. **Close the issue** — after the PR merges, run `doit pr_merge --auto-close` (or `gh issue close <n>`) to close the linked issue and post a closing comment.
 
-### Dual-agent workflow
+### Multi-agent workflow
 
-The dual-agent flow replaces the planning and (optionally) review steps with orchestrated calls that spawn Claude and Gemini in **isolated contexts**. The design intent is that neither agent can bias the other: each generates its output without seeing the other's work, and the orchestrating Claude agent in the main conversation posts both raw outputs plus a synthesis.
+The multi-agent flow replaces the planning and (optionally) review steps with orchestrated calls that spawn any combination of agents in **isolated contexts**. The design intent is that no agent can bias another: each generates its output without seeing the others' work, and the orchestrating agent in the main conversation posts all raw outputs plus a synthesis.
 
-The Gemini commands invoked from the orchestrator (`/plan-issue-stdout` and `/review-pr`) are **output-only**: Gemini does not post to GitHub itself. The orchestrating Claude agent captures Gemini's stdout and posts it via `gh`. (Gemini's standalone planning command, `/plan-issue`, does post directly — but `/plan-both` invokes the stdout-only variant to avoid duplicate comments.)
+Each agent's output is posted as a separate comment. The orchestrator is the only agent that writes to GitHub — all other agents run in non-interactive mode and emit to stdout only.
 
-1. **`/plan-both <n>`** — replaces `/plan-issue`. Claude validates the issue, then in parallel (a) spawns a general-purpose subagent to produce a Claude plan and (b) invokes `gemini -p "/plan-issue-stdout <n>" --yolo` to produce a Gemini plan. Both are posted as separate comments on the issue, Claude synthesizes a combined plan, reviews it with the user, and posts the approved synthesized plan.
-2. **`/implement <n>`** — same as the single-agent flow. The synthesized plan comment is the input.
-3. **`/review-both`** — runs after a PR exists. In parallel spawns a Claude review subagent and invokes `gemini -p "/review-pr" --yolo`, posts both reviews as PR comments, and posts a combined synthesis listing consensus findings, agent-specific findings, and a combined verdict. Alternatively, **`/gemini-review`** runs only the Gemini review and posts it (useful when the user wants a second opinion without a full Claude review).
-4. **`/finalize`**, merge, and **`/close-issue <n>`** — same as the single-agent flow.
+1. **`/multi-plan <ais...> <n>`** — takes a list of agent names (e.g. `claude gemini`) and an issue number. Each listed agent independently generates a plan in an isolated context; all plans are posted as separate issue comments. The orchestrating agent synthesizes a combined plan, reviews it with the user, and posts the approved synthesized plan.
+2. **`/<currentai>:implement <n>`** — same as the single-agent flow. The synthesized plan comment is the input.
+3. **`/multi-review <ais...>`** — takes a list of agent names. Each listed agent independently reviews the current branch's PR; all reviews are posted as separate PR comments. The orchestrating agent synthesizes findings into a combined verdict. A user-approval gate precedes the synthesis post.
+4. **`/multi-adversarial-review <ais...>`** — takes a list of agent names. Each listed agent independently challenges the current changes; all adversarial reviews are synthesized. If a PR exists the synthesis is posted; otherwise it appears in-conversation only. A user-approval gate precedes posting.
+5. **`/ghi-finalize`**, merge, and **`doit pr_merge --auto-close`** — same as the single-agent flow.
 
 ### Diagnostic command
 
-**`/where-am-i`** can be invoked at any point. It inspects the current branch, issue state, plan comment, uncommitted changes, unpushed commits, and open PRs, then reports a status summary and the suggested next command. It has no side effects.
+**`/ghi-status`** can be invoked at any point. It inspects the current branch, issue state, plan comment, uncommitted changes, unpushed commits, and open PRs, then reports a status summary and the suggested next command. It has no side effects.
 
 ## Command reference
 
 Entries are alphabetical. Each one names the command, its arguments, what it does, its position in the workflow, and any design note worth knowing.
 
-### `/close-issue <n>`
+### `/<ai>:adversarial-review [focus]` (Copilot: `/<ai>-adversarial-review`)
 
-**Args:** issue number. **Source:** `.claude/commands/close-issue.md`.
+**Args:** optional focus area. **Sources:** `.claude/commands/claude/adversarial-review.md`, `.gemini/commands/gemini/adversarial-review.toml`, `.agents/skills/codex-adversarial-review/SKILL.md` (self-action); `.claude/commands/<target>/adversarial-review.md`, `.gemini/commands/<target>/adversarial-review.toml`, `.github/skills/<target>-adversarial-review/SKILL.md` (cross-agent delegation). Copilot uses skill names instead of slash commands (see [Copilot section](#copilot) below).
 
-Verifies a merged PR references `#n`, updates task checkboxes in the issue body, posts the closing comment `Addressed in PR #<pr-number>`, closes the issue via `gh issue close`, then scans the PR body and comments for related issue references (`Addresses`, `Part of`, `Related to`, `Closes`, `Fixes`, `References`, bare `#N`) and asks the user individually whether to close each open related issue. **Workflow position:** last step of both single-agent and dual-agent flows. **Design note:** never closes an issue without a merged PR unless the user explicitly confirms; never closes related issues without per-issue confirmation.
+Runs an adversarial review using the host agent (self-action) or delegates to a target agent (cross-agent). The review is read-only: it pressure-tests design choices, hidden assumptions, tradeoffs, alternatives, and failure modes. The host agent presents findings in the format Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering. If a PR exists, the user is asked whether to post the review as a PR comment. **Workflow position:** optional adversarial challenge before `/ghi-finalize`. **Design note:** in the self-action form, the host agent does the review work itself; no external CLI is invoked.
 
-### `/finalize`
+### `/<ai>:implement <n>` (Copilot: `/<ai>-implement <n>`)
 
-**Args:** none. **Source:** `.claude/commands/finalize.md`.
+**Args:** issue number. **Sources:** `.claude/commands/claude/implement.md`, `.gemini/commands/gemini/implement.toml`, `.agents/skills/codex-implement/SKILL.md` (self-action); cross-agent delegation files under `.claude/commands/<target>/implement.md`, `.gemini/commands/<target>/implement.toml`, `.github/skills/<target>-implement/SKILL.md`. Copilot uses skill names instead of slash commands (see [Copilot section](#copilot) below).
+
+Validates that the issue is open and that a plan comment exists (otherwise instructs the user to run `/<currentai>:plan <n>` first). Checks the current branch: if already on `<type>/<n>-*` it resumes work on that branch, otherwise it checks out `main`, pulls, and creates a new branch. For Claude, it then spawns the custom `implement-worker` subagent (defined in `.claude/agents/implement-worker.md`) that reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches the plan via `gh api`, implements files and tests, and runs `doit check`. For Gemini and Copilot, implementation runs inline in the main conversation. For Codex, the `$codex-implement` skill implements inline in the Codex session. **Workflow position:** after plan exists, before `/ghi-finalize`.
+
+### `/<ai>:plan <n>` (Copilot: `/<ai>-plan <n>`)
+
+**Args:** issue number. **Sources:** `.claude/commands/claude/plan.md`, `.gemini/commands/gemini/plan.toml`, `.agents/skills/codex-plan/SKILL.md` (self-action); cross-agent delegation files under `.claude/commands/<target>/plan.md`, `.gemini/commands/<target>/plan.toml`, `.github/skills/<target>-plan/SKILL.md`. Copilot uses skill names instead of slash commands (see [Copilot section](#copilot) below).
+
+Runs in the main conversation context (not a subagent) so the user can ask questions and refine the plan interactively. For Claude, enters plan mode. Validates the issue, warns if a plan comment already exists, reads `AGENTS.md`, fetches issue details, explores the codebase, and drafts a plan with the standard sections (Overview, Files to Create/Modify, Test Plan, Documentation, Validation). Iterates until the user approves, then posts the approved plan as an issue comment. **Workflow position:** first step of the single-agent workflow. **Design note:** Claude and Gemini share the `<ai>:<action>` naming convention. Copilot uses `<ai>-<action>` (hyphen) because skill names cannot contain colons; Codex uses `$<ai>-<action>` and `$delegate-<ai>-<action>`.
+
+### `/<ai>:review [focus]` (Copilot: `/<ai>-review`)
+
+**Args:** optional focus area. **Sources:** `.claude/commands/claude/review.md`, `.gemini/commands/gemini/review.toml`, `.agents/skills/codex-review/SKILL.md` (self-action); `.claude/commands/<target>/review.md`, `.gemini/commands/<target>/review.toml`, `.github/skills/<target>-review/SKILL.md` (cross-agent delegation). Copilot uses skill names instead of slash commands (see [Copilot section](#copilot) below).
+
+Runs a PR review using the host agent (self-action) or delegates to a target agent (cross-agent). Gets the PR diff and branch context, reads project standards, evaluates correctness, style, testing, security, documentation, architecture, and breaking changes. Presents findings in the format Summary / Findings (Critical / Suggestions / Positive) / Verdict. The user is asked whether to post the review as a PR comment before posting. **Workflow position:** after `/claude:implement`, before `/ghi-finalize`.
+
+### `/ghi-finalize`
+
+**Args:** none. **Source:** `.claude/commands/ghi-finalize.md`.
 
 Operates on the current feature branch, assuming implementation and review are complete. In the main context it detects the branch, extracts the issue number from the branch name, fetches issue details, and checks for uncommitted changes. It then spawns a general-purpose subagent that reads `AGENTS.md`, `.github/CONTRIBUTING.md`, and `.github/pull_request_template.md`, reviews changed files for doc/ADR updates, runs `doit check`, and drafts a commit message plus a PR body written to a temp file. The main context then presents the drafts to the user, waits for explicit approval, stages files, commits, and creates the PR via `doit pr --title=... --body-file=...`. **Workflow position:** after implementation and review. **Design note:** will not commit or create the PR without explicit user confirmation; stops if run on `main`.
 
-### `/gemini-review`
+### `/multi-adversarial-review <ais...>`
 
-**Args:** none. **Source:** `.claude/commands/gemini-review.md`.
+**Args:** one or more agent names (`claude`, `gemini`, `copilot`, `codex`). **Sources:** `.claude/commands/multi-adversarial-review.md`, `.gemini/commands/multi-adversarial-review.toml`, `.copilot/commands/multi-adversarial-review.md`, `.agents/skills/multi-adversarial-review/SKILL.md`.
 
-Runs in the main conversation context. Verifies a PR exists for the current branch, invokes `gemini -p "/review-pr" --yolo` to get a Gemini-authored review as stdout markdown, and posts the output as a comment on the PR via `gh pr comment`, then reports a brief summary to the user. **Workflow position:** optional second-opinion review on an open PR. **Design note:** Gemini does not post to GitHub itself — the orchestrating Claude agent posts the captured stdout.
+Runs each listed agent in an isolated context to independently challenge the current uncommitted changes and the current branch vs `main`. Each agent outputs an adversarial review (Direction Critique / Hidden Assumptions / Failure Modes / Alternatives Worth Considering); all reviews are synthesized into a combined challenge with consensus and per-agent-only findings. A user-approval gate precedes posting. If a PR exists the synthesis is posted as a PR comment; otherwise it is presented in-conversation only. **Workflow position:** optional adversarial challenge before `/ghi-finalize`. **Design note:** no agent sees any other agent's output while drafting; every non-self agent runs in non-interactive mode and writes only to stdout.
 
-### `/implement <n>`
+### `/multi-plan <ais...> <issue#>`
 
-**Args:** issue number. **Source:** `.claude/commands/implement.md`.
+**Args:** one or more agent names (`claude`, `gemini`, `copilot`, `codex`) followed by the issue number. **Sources:** `.claude/commands/multi-plan.md`, `.gemini/commands/multi-plan.toml`, `.copilot/commands/multi-plan.md`, `.agents/skills/multi-plan/SKILL.md`.
 
-Validates that the issue is open and that a plan comment exists (otherwise instructs the user to run `/plan-issue <n>` first). Checks the current branch: if already on `<type>/<n>-*` it resumes work on that branch, otherwise it checks out `main`, pulls, and creates a new branch whose type is derived from the issue's labels (`enhancement`→`feat`, `bug`→`fix`, `refactor`→`refactor`, `documentation`→`docs`, `chore`→`chore`, else `issue`). It then spawns the custom `implement-worker` subagent (defined in `.claude/agents/implement-worker.md`) that reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches the plan via `gh api`, implements files and tests, and runs `doit check`, fixing failures rather than giving up. The main context receives only the summary. **Workflow position:** after plan exists, before `/finalize`. **Design note:** the subagent pattern keeps the main conversation context clean. The command now spawns `implement-worker` rather than the built-in `general-purpose` subagent. The custom subagent has `permissionMode: default` in its YAML frontmatter — per Claude Code's documented sub-agent precedence rules, this should escape parent plan mode because plan mode is not in the parent-overrides-child list. The status-line preamble warning (telling the user to check for "plan mode" before running) is retained as belt-and-suspenders while the override is empirically validated; it can be removed in a follow-up once confirmed on the shipping Claude Code version.
+Validates the issue, warns if plan comments already exist, then generates independent plans from each listed agent in isolated contexts. Posts each plan as a separate issue comment, synthesizes a combined plan that highlights agreements and divergences, reviews the synthesis with the user, and only posts the synthesized plan after explicit approval. **Workflow position:** first step of the multi-agent workflow. **Design note:** isolated contexts are mandatory so no agent can see another's output while drafting; the orchestrating agent is the only one that writes to GitHub.
 
+### `/multi-review <ais...>`
 
-### `/plan-both <n>`
+**Args:** one or more agent names (`claude`, `gemini`, `copilot`, `codex`). **Sources:** `.claude/commands/multi-review.md`, `.gemini/commands/multi-review.toml`, `.copilot/commands/multi-review.md`, `.agents/skills/multi-review/SKILL.md`.
 
-**Args:** issue number. **Source:** `.claude/commands/plan-both.md`.
+Verifies a PR exists for the current branch, warns if reviews already exist, then generates independent code reviews from each listed agent in isolated contexts. Posts each review as a separate PR comment, synthesizes findings into a combined verdict (consensus findings, per-agent-only findings, combined verdict). A user-approval gate precedes the synthesis post. **Workflow position:** after `/<currentai>:implement`, before `/ghi-finalize`, in the multi-agent workflow. **Design note:** same isolation guarantee as `/multi-plan` — no reviewer sees another's output; the synthesis is posted after all raw reviews so readers can audit it against the sources.
 
-Dual-agent replacement for `/plan-issue`. Validates the issue, warns if plan comments already exist, then generates two plans in isolated contexts — a Claude plan via a spawned subagent and a Gemini plan via `gemini -p "/plan-issue-stdout <n>" --yolo` (the stdout-only variant of Gemini's planner) — posts both as separate issue comments, synthesizes a combined plan that highlights agreements and divergences, reviews the synthesis with the user, and only posts the synthesized plan after explicit approval. **Workflow position:** first step of the dual-agent workflow. **Design note:** isolated contexts are mandatory so neither agent can see the other's output while drafting; Claude is the orchestrator and the only agent that writes to GitHub.
+### `/ghi-status`
 
-### `/plan-issue <n>`
-
-**Args:** issue number. **Source:** `.claude/commands/plan-issue.md`.
-
-Runs in the main conversation context (not a subagent) so the user can ask questions and refine the plan interactively. Enters plan mode, validates the issue, warns if a plan comment already exists, reads `AGENTS.md` and `.claude/CLAUDE.md`, fetches issue details, explores the codebase, and drafts a plan with the standard sections (Overview, Files to Create/Modify, Test Plan, Documentation, Validation). It iterates inside plan mode with `AskUserQuestion` until the user approves, then exits plan mode and posts the approved plan as an issue comment. **Workflow position:** first step of the single-agent workflow. **Design note:** plan mode is preserved throughout iteration; exiting plan mode means "post the approved plan", nothing more.
-
-### `/review-both`
-
-**Args:** none. **Source:** `.claude/commands/review-both.md`.
-
-Dual-agent PR review. Verifies a PR exists for the current branch, then in parallel spawns a general-purpose Claude review subagent and invokes `gemini -p "/review-pr" --yolo`, posts both reviews as separate PR comments, and posts a synthesis listing consensus findings (both agents flagged), Claude-only findings, Gemini-only findings, and a combined verdict. **Workflow position:** after `/implement`, before `/finalize`, in the dual-agent workflow. **Design note:** same isolation guarantee as `/plan-both` — neither reviewer sees the other's output; the synthesis is posted after both raw reviews so readers can audit the synthesis against the sources.
-
-### `/where-am-i`
-
-**Args:** none. **Source:** `.claude/commands/where-am-i.md`.
+**Args:** none. **Source:** `.claude/commands/ghi-status.md`.
 
 Inspects the current git state (branch, uncommitted changes, recent log), extracts the issue number from the branch name if on a feature branch, checks for a plan comment, unpushed commits, and open PRs, then reports a status summary and suggests the next command to run. **Workflow position:** any time. **Design note:** read-only and side-effect-free — safe to run whenever the user is unsure where they are in the lifecycle.
+
+### `/checkpoint <slug>` and `/restore <slug>`
+
+**Args:** optional kebab-case slug. **Sources:** `.claude/commands/checkpoint.md`, `.claude/commands/restore.md` (Claude); `.gemini/commands/checkpoint.md`, `.gemini/commands/restore.md` (Gemini); `.agents/skills/checkpoint/SKILL.md`, `.agents/skills/restore/SKILL.md` (Codex).
+
+Pause-and-resume helpers for long-running workstreams. `/checkpoint` writes a paste-ready resumption prompt to `tmp/checkpoints/{inv_epoch}-{slug}.md`; `/restore` reads the matching file and treats its contents as the session's initial instructions. The `inv_epoch` prefix is a 10-digit decreasing integer so default `ls` lists newest first; users see only the slug. If `/restore` is invoked without a slug, it picks the most recent checkpoint. **Naming:** `checkpoint`/`restore` was chosen over `snapshot`/`resume` to avoid collisions with built-in slash commands across all four supported agents (Claude Code, Gemini CLI, Codex CLI, Copilot CLI all reserve `/resume`; Gemini also reserves `/snapshot`).
+
+**Cross-agent portability:** `tmp/checkpoints/` is intentionally shared (not per-agent), so a checkpoint taken in Claude can be restored in Gemini or Codex and vice versa. This is the documented exception to the `tmp/agents/<agent-type>/` rule in `AGENTS.md`. **Workflow position:** any time, independent of the issue lifecycle. **Design note:** checkpoints are immutable once written; the user is expected to verify referenced issues/PRs are still current before acting on stale references. **When to use it:** at the end of a session when work is unfinished and you want a clean handoff into the next session — capture the goal, current branch state, recommended next step, and any user direction or constraints that should bind the future session.
+
+**Auto-checkpoint (PreCompact / SessionStart hooks):** Claude Code also ships two lifecycle hooks that automate the pause/resume pattern for the most common context-loss event — autocompact firing mid-task. The `PreCompact` hook synthesizes a checkpoint to `tmp/checkpoints/{inv_epoch}-auto-precompact.md` before compaction; the `SessionStart` hook (matcher `compact|resume`) injects the newest auto-precompact file into the new session's context automatically. Auto-precompact files share the same filename convention and directory as manual `/checkpoint` files, so `/restore auto-precompact` also works. Set `CLAUDE_NO_AUTO_RESTORE=1` to opt out of the automatic restore; set `CLAUDE_RESTORE_ANY=1` to widen the restore glob to any `*.md` checkpoint. See [Auto-Checkpoint and Session-Restore Hooks](auto-checkpoint-hook.md) for full details.
 
 ## Gemini
 
@@ -104,52 +120,42 @@ Gemini-first users can complete the full issue lifecycle using Gemini-native com
 
 ### Standalone workflow
 
-1. **`/plan-issue <n>` (Gemini)** — Gemini reads the issue and project rules, explores the codebase, and drafts a plan inline in the conversation. After the user approves the plan, Gemini posts it as a comment on the issue with the header `## Implementation Plan for #<n>: <title>`.
+1. **`/gemini:plan <n>`** — Gemini reads the issue and project rules, explores the codebase, and drafts a plan inline in the conversation. After the user approves the plan, Gemini posts it as a comment on the issue with the header `## Implementation Plan for #<n>: <title>`.
 2. **User review of the plan** — same as Claude flow.
-3. **`/implement <n>` (Gemini)** — Gemini validates the plan comment, creates the feature branch, and implements the changes inline in the conversation. It runs `doit check` to verify the implementation.
+3. **`/gemini:implement <n>`** — Gemini validates the plan comment, creates the feature branch, and implements the changes inline in the conversation. It runs `doit check` to verify the implementation.
 4. **User review of the changes** — same as Claude flow.
-5. **`/finalize` (Gemini)** — Gemini detects the branch and issue, checks for doc/ADR updates, runs `doit check`, and drafts the commit message and PR body. After user approval, it stages, commits, and creates the PR via `doit pr`.
+5. **`/ghi-finalize` (Gemini)** — Gemini detects the branch and issue, checks for doc/ADR updates, runs `doit check`, and drafts the commit message and PR body. After user approval, it stages, commits, and creates the PR via `doit pr`.
 
 ### Command reference
 
-#### `/finalize` (Gemini)
+#### `/ghi-finalize` (Gemini)
 
-**Args:** none. **Source:** `.gemini/commands/finalize.md`.
+**Args:** none. **Source:** `.gemini/commands/ghi-finalize.md`.
 
 Gemini-native implementation of the finalize command. Detects the branch and issue, checks for uncommitted changes, reviews changed files for documentation/ADR updates, runs `doit check`, and drafts a commit message and PR body (written to `tmp/agents/gemini/pr-body-issue-<n>.md`). After user approval, it stages files, commits, and creates the PR via `doit pr`. **Workflow position:** after implementation and review. **Design note:** unlike the Claude version, all operations happen inline in the main conversation context.
 
-#### `/implement <n>` (Gemini)
+#### `/gemini:implement <n>`
 
-**Args:** issue number. **Source:** `.gemini/commands/implement.md`.
+**Args:** issue number. **Source:** `.gemini/commands/gemini/implement.toml`.
 
-Gemini-native implementation of the implement command. Validates the issue and plan comment, creates the feature branch, and implements the changes inline in the conversation. Runs `doit check` to verify the implementation. **Workflow position:** after plan exists, before `/finalize`. **Design note:** performs all implementation steps directly in the main conversation context rather than spawning a subagent.
+Gemini-native implementation of the implement command. Validates the issue and plan comment, creates the feature branch, and implements the changes inline in the conversation. Runs `doit check` to verify the implementation. **Workflow position:** after plan exists, before `/ghi-finalize`. **Design note:** performs all implementation steps directly in the main conversation context rather than spawning a subagent.
 
-#### `/plan-issue <n>` (Gemini)
+#### `/gemini:plan <n>`
 
-**Args:** issue number. **Source:** `.gemini/commands/plan-issue.md`.
+**Args:** issue number. **Source:** `.gemini/commands/gemini/plan.toml`.
 
-Gemini-native standalone planning command. Validates the issue, reads `AGENTS.md`, explores the codebase, and drafts a plan inline in the conversation. Iterates with the user until the plan is approved, then posts it to the issue as a comment via `gh issue comment`. Mirrors the behavior of Claude's `/plan-issue`. **Workflow position:** start of standalone Gemini workflow, before `/implement`. **Design note:** Gemini has no plan-mode equivalent, so iteration happens in the regular conversation context.
-
-#### `/plan-issue-stdout <n>` (Gemini)
-
-**Args:** issue number. **Source:** `.gemini/commands/plan-issue-stdout.md`.
-
-Orchestration-only variant of `/plan-issue`. Invoked by Claude's `/plan-both` command via `gemini -p "/plan-issue-stdout <n>" --yolo`. Fetches the issue, reads `AGENTS.md`, explores the codebase, and outputs a plan in the standard format to stdout, signed `*Plan by: Gemini*`. **Workflow position:** called indirectly from `/plan-both`. **Design note:** output-only — the command explicitly instructs Gemini not to post to GitHub; the orchestrating Claude agent captures stdout and posts it. Split from `/plan-issue` so the standalone command can post directly without producing duplicate comments under orchestration.
-
-#### `/review-pr` (Gemini)
-
-**Args:** none. **Source:** `.gemini/commands/review-pr.md`.
-
-Invoked by Claude's `/review-both` and `/gemini-review` commands via `gemini -p "/review-pr" --yolo`. Identifies the current branch's PR, scans for `Addresses #XXX` to find the issue, reads `AGENTS.md` and `.github/CONTRIBUTING.md`, runs `gh pr diff`, reviews the changes for correctness, style, testing, security, documentation, architecture, and breaking changes, and outputs a review in the standard format to stdout, signed `*Review by: Gemini*`. **Workflow position:** called indirectly from `/review-both` or `/gemini-review`. **Design note:** output-only for the same reason as the Gemini plan command.
+Gemini-native standalone planning command. Validates the issue, reads `AGENTS.md`, explores the codebase, and drafts a plan inline in the conversation. Iterates with the user until the plan is approved, then posts it to the issue as a comment via `gh issue comment`. **Workflow position:** start of standalone Gemini workflow, before `/gemini:implement`. **Design note:** Gemini has no plan-mode equivalent, so iteration happens in the regular conversation context.
 
 ## Codex
 
 Codex does not use repo-defined slash commands in this template. Instead, the Codex workflow is provided through **repo-scoped skills** under `.agents/skills/`, which Codex can invoke through its built-in `/skills` browser or explicit mentions such as `$codex-plan`, `$codex-implement`, and `$ghi-finalize`.
 
-**Workflow coverage:** the checked-in Codex skills cover planning, implementation, and finalization through PR creation. They preserve the same repo artifact contract used by the Claude flow:
+**Workflow coverage:** the checked-in Codex skills cover planning, implementation, review, adversarial review, and finalization through PR creation. They preserve the same repo artifact contract used by the Claude flow:
 
 - `$codex-plan` posts the approved plan comment with the header `## Implementation Plan for #<n>: <title>`
 - `$codex-implement` creates or resumes the issue branch and finishes with `doit check`
+- `$codex-review` reviews the current branch's PR and posts findings after user approval
+- `$codex-adversarial-review` runs an adversarial challenge review
 - `$ghi-finalize` drafts the commit and PR artifacts and uses `doit pr` after explicit approval
 
 **Config and safety:** `.codex/config.toml` still configures approvals and hook wiring for Codex. The shared dangerous-command hook at `tools/hooks/ai/block-dangerous-commands.py` applies to Codex, and the approval-policy deny rules remain a secondary defense layer.
@@ -158,26 +164,81 @@ Codex does not use repo-defined slash commands in this template. Instead, the Co
 
 ## Copilot
 
-GitHub Copilot CLI automatically discovers project skills from `.claude/commands/`. All workflow commands (`/plan-issue`, `/implement`, `/finalize`, `/close-issue`, `/where-am-i`, etc.) are available in Copilot sessions without any additional files.
+GitHub Copilot CLI **does not** discover slash commands from `.claude/commands/` or `.copilot/commands/`. Per the installed `@github/copilot` SDK (`sdk/index.d.ts`), Copilot CLI discovers project skills only from `skills/` directories: `.github/skills/`, `.agents/skills/`, and `.claude/skills/` (plus the corresponding personal paths under `~/`). It does not read any `commands/` directory.
 
-**Config directory:** `.copilot/` — established as the Copilot CLI config directory for this repo, parallel to `.claude/`, `.gemini/`, and `.codex/`.
+Because skill names are derived from their directory name and **cannot contain colons**, Copilot's surface for the cross-agent matrix uses `<target>-<action>` (hyphen), not `<target>:<action>` (colon). The functional behavior is identical to the other CLIs — only the slash name differs.
+
+**Self-action and cross-agent skills:** All 16 cells of the cross-agent matrix for Copilot host live under `.github/skills/<target>-<action>/SKILL.md`:
+
+- Self-action: `/copilot-plan`, `/copilot-implement`, `/copilot-review`, `/copilot-adversarial-review`
+- To Claude: `/claude-plan`, `/claude-implement`, `/claude-review`, `/claude-adversarial-review`
+- To Codex: `/codex-plan`, `/codex-implement`, `/codex-review`, `/codex-adversarial-review`
+- To Gemini: `/gemini-plan`, `/gemini-implement`, `/gemini-review`, `/gemini-adversarial-review`
+
+**Why `.github/skills/` and not `.claude/skills/`?** Copilot reads both, but Claude also reads `.claude/skills/`. Placing the bridges there would surface them as a second set of slash commands in Claude alongside the native `<ai>:<action>` commands — visible noise. `.github/skills/` is read by Copilot but not by Claude (or by Gemini/Codex), so it's the only Copilot-only project skill path.
+
+**Config directory:** `.copilot/` — established as the Copilot CLI config directory for this repo, parallel to `.claude/`, `.gemini/`, and `.codex/`. Note that no `.copilot/commands/<target>/` files are needed (or read).
 
 **Dangerous command hook:** Already wired in `.github/hooks/copilot-hooks.json`. It invokes `tools/hooks/ai/block-dangerous-commands.py` as a `preToolUse` hook, blocking dangerous shell commands before they execute. See [AI Command Blocking](command-blocking.md) for details.
 
-**Implement-worker subagent:** Shared with Claude — defined in `.claude/agents/implement-worker.md`. Copilot CLI's `task` tool reads this file when `/implement` spawns the subagent.
+**Implement-worker subagent:** Shared with Claude — defined in `.claude/agents/implement-worker.md`. Copilot CLI's `task` tool reads this file when `/claude-implement` spawns the subagent.
 
-**No parallel command files needed:** Because Copilot CLI discovers skills from `.claude/commands/` directly, you do not need to maintain a separate `.copilot/commands/` directory unless you want to override Claude-specific behavior for Copilot sessions.
+**Known limitation — `delegate-*` skill bleed:** Because Copilot also reads `.agents/skills/`, it surfaces the Codex-only `delegate-<target>-<action>` skills (12 of them) alongside the canonical `<target>-<action>` ones. The Codex-only skills shell out to Codex's syntax and are wasted noise in a Copilot session. Copilot exposes a `disabledSkills` config field (see `~/.copilot/config.json`), but **only at user level — there is no repo-level setting for it.** If you want to silence the delegate-* skills in Copilot, add them to your user config manually:
+
+```json
+{
+  "disabledSkills": [
+    "delegate-claude-plan",
+    "delegate-claude-implement",
+    "delegate-claude-review",
+    "delegate-claude-adversarial-review",
+    "delegate-codex-plan",
+    "delegate-codex-implement",
+    "delegate-codex-review",
+    "delegate-codex-adversarial-review",
+    "delegate-gemini-plan",
+    "delegate-gemini-implement",
+    "delegate-gemini-review",
+    "delegate-gemini-adversarial-review",
+    "delegate-copilot-plan",
+    "delegate-copilot-implement",
+    "delegate-copilot-review",
+    "delegate-copilot-adversarial-review"
+  ]
+}
+```
 
 ## Adding a new slash command
 
-1. **Pick the location.** Claude commands live in `.claude/commands/<name>.md` and become `/<name>` in Claude Code. Gemini commands live in `.gemini/commands/<name>.md` and become `/<name>` in Gemini CLI. Copilot CLI auto-discovers skills from `.claude/commands/` — no separate `.copilot/commands/<name>.md` is needed unless you want to override Claude-specific behaviour for Copilot sessions.
+1. **Pick the location.** Claude commands live in `.claude/commands/<name>.md` and become `/<name>` in Claude Code. Gemini commands live in `.gemini/commands/<name>.md` and become `/<name>` in Gemini CLI. Copilot CLI discovers **skills only** from `skills/` directories (`.github/skills/`, `.agents/skills/`, `.claude/skills/`) — never from `commands/`. To expose a Copilot-only command, author it as `.github/skills/<name>/SKILL.md` (with YAML frontmatter) — `.github/skills/` is the only Copilot project skill path that Claude does **not** also read. The slash name becomes `/<name>` because skill names cannot contain colons.
 2. **Use the CLI file format** — not the `docs/` frontmatter format. Start with a top-level `# Title` heading, follow with a one-line description (which may include the `$ARGUMENTS` placeholder if the command takes arguments), then a `## Instructions` section containing the step-by-step body. **Do not add YAML frontmatter.** The CLIs expect plain markdown; frontmatter would appear verbatim in the rendered prompt.
-3. **Use `$ARGUMENTS` for inputs.** When the user invokes `/<command> foo bar`, every `$ARGUMENTS` occurrence in the file is substituted with `foo bar` before the command body is sent to the model. For commands that take no arguments (like `/finalize` or `/where-am-i`), omit the placeholder.
-4. **Decide: subagent or main context?** Delegate to a general-purpose subagent via the Task tool when the command does heavy codebase exploration, writes files, or runs long commands whose output would bloat the main conversation — `.claude/commands/implement.md` is the canonical example. Run in the main context when the user needs to interact step by step (plan mode, iteration, explicit approvals) — `.claude/commands/plan-issue.md` is the canonical example.
+3. **Use `$ARGUMENTS` for inputs.** When the user invokes `/<command> foo bar`, every `$ARGUMENTS` occurrence in the file is substituted with `foo bar` before the command body is sent to the model. For commands that take no arguments (like `/ghi-finalize` or `/ghi-status`), omit the placeholder.
+4. **Decide: subagent or main context?** Delegate to a general-purpose subagent via the Task tool when the command does heavy codebase exploration, writes files, or runs long commands whose output would bloat the main conversation — `.claude/commands/claude/implement.md` is the canonical example. Run in the main context when the user needs to interact step by step (plan mode, iteration, explicit approvals) — `.claude/commands/claude/plan.md` is the canonical example.
 5. **Update this document** when you add or remove a command. The command reference section should list every file under `.claude/commands/` and `.gemini/commands/`.
+
+## Cross-agent delegation matrix
+
+This template ships a `<target>:<action>` matrix where `<target>` can be **the same agent** (self-action) or **any of the other three** (cross-agent delegation). Self-action (`/claude:plan`, `/gemini:plan`, etc.) and cross-agent delegation (`/gemini:plan` from Claude, `/claude:plan` from Gemini, etc.) share the same `<ai>:<action>` naming convention. The full design — convention, file layout, prefix mapping (`/foo` vs `$foo` for Codex), Hybrid C runtime behavior, and the `.agents/skills/` ↔ Gemini conflict mitigation — is documented separately:
+
+→ See [Cross-Agent Delegation Matrix](cross-agent-delegation.md).
+
+Quick reference:
+
+```text
+# In Claude Code / Gemini CLI (colon separator):
+/<target>:<action> [args]      # e.g. /codex:plan 42, /gemini:adversarial-review
+
+# In Copilot CLI (hyphen separator — skill names cannot contain colons):
+/<target>-<action> [args]      # e.g. /codex-plan 42, /gemini-adversarial-review
+
+# In Codex CLI (skills, not slash commands; hyphen separator):
+$<target>-<action> [args]              # self-action: $codex-plan 42
+$delegate-<target>-<action> [args]     # cross-agent: $delegate-claude-implement 42
+```
 
 ## See also
 
+- [Cross-Agent Delegation Matrix](cross-agent-delegation.md) — convention, matrix, and per-host invocation for the `<target>:<action>` family.
 - [First 5 Minutes with an AI Agent](first-5-minutes.md) — narrative onboarding walkthrough showing the workflow end to end.
 - [AI Agent Setup Guide](../AI_SETUP.md) — per-CLI configuration and whitelists.
 - [Architectural Conventions](architectural-conventions.md) — imperative rules for AI-generated code.

--- a/docs/development/ai/statusline.md
+++ b/docs/development/ai/statusline.md
@@ -72,6 +72,17 @@ COLOR="blue"
 | slate    | 60        | Dark blue-gray |
 | cyan     | 37        | Bright, tech |
 
+The usage segment (opt-in, see below) uses three additional fixed colors that are independent
+of the `COLOR` theme:
+
+| Field | Variable | ANSI Code | Description |
+|-------|----------|-----------|-------------|
+| Percent value | `C_PCT` | 71 (green) | "value" semantics — current consumption |
+| `@` separator | `C_DIM` | 238 (dark gray) | dim join between percent and time |
+| Reset time | `C_TIME` | 136 (gold) | "schedule" semantics — when the bucket ends |
+
+Edit `.claude/statusline-command.sh` to change these.
+
 ### Removing Features
 
 Comment out or remove lines in the "Build output" section of the script:
@@ -84,6 +95,57 @@ output="📁 ${dir}"
 # [[ -n "$gh_user" ]] && output+="\n@${gh_user}"  # Remove GitHub username
 [[ -n "$branch" ]] && output+=" | 🔀 ${branch} ${git_status}"
 ```
+
+## Opt-In: Claude Max Usage Display
+
+For Claude Max subscribers, an optional helper at `tools/statusline/claude-usage.sh` displays
+weekly + 5-hour utilization. The default statusline runs the helper only when the
+`CLAUDE_USAGE_STATUSLINE` env var is set, so the default behavior is unchanged.
+
+> **Beta API**: This helper hits an undocumented OAuth endpoint (`/api/oauth/usage`)
+> gated by the `anthropic-beta: oauth-2025-04-20` header. Anthropic may change or remove
+> this endpoint without notice. When the official `claude --usage` flag ships
+> ([anthropics/claude-code#20399](https://github.com/anthropics/claude-code/issues/20399)),
+> prefer it.
+
+### Enable
+
+Set `CLAUDE_USAGE_STATUSLINE=1` in your shell environment:
+
+```bash
+# In ~/.zshrc, ~/.bashrc, or .envrc.local
+export CLAUDE_USAGE_STATUSLINE=1
+```
+
+Restart Claude Code. The statusline appends `5h:N%@HHMM wk:N%@aaa-HHMM` to the model/context line.
+Times are shown in your local timezone.
+To disable temporarily: `unset CLAUDE_USAGE_STATUSLINE` and restart Claude Code.
+
+Example output (helper segment is the trailing portion of the third line):
+
+```
+📁 project | 🐍 .venv | Python: 3.12.12
+@username | 🔀 main (0 files uncommitted, synced 5m ago)
+Claude Opus 4.5 | ▓▓░░░░░░░░ ~10% of 200k tokens | 5h:25%@1800 · wk:6%@Mon-2000
+```
+
+### Cache behavior
+
+Responses are cached at `${XDG_CACHE_HOME:-~/.cache}/claude-usage.json` for 60 seconds.
+Adjust `MAX_AGE` at the top of the script. To force a refresh: `rm ~/.cache/claude-usage.json`.
+
+### Helper requirements
+
+- Active Claude Code OAuth login (`${CLAUDE_CONFIG_DIR:-~/.claude}/.credentials.json`)
+- `curl` for HTTPS
+- `jq` (already required by base statusline)
+- `python3` for ISO-8601 timestamp formatting (already a project dev dependency)
+
+### Helper troubleshooting
+
+- **Outputs `?`**: missing/expired credentials, no network, beta endpoint changed schema, or
+  curl timeout (5s). Debug with `bash -x tools/statusline/claude-usage.sh`.
+- **Stale value**: cache has not expired. Delete the cache file or wait 60s.
 
 ## Requirements
 

--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -1,0 +1,619 @@
+---
+title: AI Agent Token-Efficiency Add-Ons
+description: Opt-in catalogue of external tools for reducing token usage in Claude Code sessions
+audience:
+  - contributors
+  - ai-agents
+  - operators
+tags:
+  - ai
+  - token-efficiency
+  - add-ons
+---
+
+# AI Agent Token-Efficiency Add-Ons
+
+## Purpose
+
+This page is an **opt-in menu** for operators of larger downstream projects who hit token-cost or
+session-length pain points. The baseline defaults (env-var settings for Claude, `chatCompression` settings for Gemini) are
+already on for everyone — see [AI Agent Setup Guide](../AI_SETUP.md).
+Add-ons here are additional investments: each has setup cost, operational burden, and in some cases
+a trust trade-off. Read the tipping-point guidance before adopting any of them.
+
+Most projects built on this template do not need these. The audience is operators running
+multi-hour sessions against large codebases where the baseline defaults are not enough.
+
+## When to consider an add-on
+
+Adopt an add-on when one or more of the following apply:
+
+- Sessions end in autocompact more than once per workday.
+- Shell command output (test runs, `find` output, diff blobs) dominates context billing.
+- AGENTS.md rules drift noticeably in long sessions — the agent ignores a documented rule late
+  in a conversation that it respected at the start.
+- You are running concurrent agents on a shared API key and token-rate costs are measurable.
+- You are working in a regulated environment and want auditable compression before tokens leave
+  the machine.
+
+## RTK (Rust Token Killer)
+
+**Repo:** [github.com/rtk-ai/rtk](https://github.com/rtk-ai/rtk)
+
+RTK is a shell-output compressor. It intercepts the stdout of commands you run through the
+Claude Code terminal, strips redundant whitespace and repeated lines, and injects a compact
+representation into the context instead of the raw output. It is written in Rust for low-overhead
+interception and ships as a standalone binary as well as bundled inside Headroom (see below).
+
+**Tipping-point:** adopt RTK when test-suite output, build logs, or `find`/`grep` results are a
+visible fraction of your context bills. If `pytest` output is 200 lines per run and you run tests
+frequently in a session, RTK compresses that cost significantly.
+
+**Per-CLI applicability:**
+
+| CLI | Works? |
+| :--- | :--- |
+| Claude Code | Yes |
+| Gemini CLI | Yes (shell interception is CLI-agnostic) |
+| GitHub Copilot CLI | Yes |
+| Codex CLI | Yes |
+
+**Install (standalone):**
+
+```bash
+# Install the Rust binary
+cargo install rtk
+
+# Wrap your shell session
+rtk -- bash
+```
+
+Once the shell is wrapped, every command Claude Code (or you) runs through the terminal has its
+output compressed automatically. No changes to `.claude/settings.local.json` are required.
+
+**Trust caveat:** RTK operates entirely on your machine and does not proxy the API — it rewrites
+the text that ends up in the context, but it never reads or forwards your API key. No significant
+trust concern beyond normal Rust binary installation hygiene.
+
+## Headroom
+
+**Repo:** [github.com/chopratejas/headroom](https://github.com/chopratejas/headroom)
+
+Headroom is a local proxy that sits between Claude Code and the Anthropic API. It intercepts
+outbound API requests and compresses conversation history, system prompts, `CLAUDE.md` content,
+and tool-call outputs **before they leave the machine**, reducing the token count sent upstream.
+It also ships RTK as a bundled dependency so you get both tools in one install.
+
+**Tipping-point:** adopt Headroom when context bills are high across the board — not just shell
+output but also system prompts and conversation history. It is the most aggressive compression
+option and gives you the broadest reduction.
+
+> **Trust caveat:** Headroom is a **MITM proxy** in your API path. All requests to the Anthropic
+> API, including your API key and full conversation content, pass through Headroom's local process.
+> **Read the source before adopting Headroom on shared or employer-owned codebases.** Confirm that
+> the binary you run matches the source at the tagged version and that no network forwarding is
+> configured. This is not a warning against Headroom itself — it is a standard due-diligence step
+> for any tool that sits in the API path.
+
+**Per-CLI applicability:**
+
+| CLI | Works? |
+| :--- | :--- |
+| Claude Code | Yes |
+| Gemini CLI | No (Gemini API endpoint differs; not tested) |
+| GitHub Copilot CLI | No (uses GitHub's Copilot endpoint, not Anthropic) |
+| Codex CLI | No (uses OpenAI endpoint) |
+
+**Install:**
+
+```bash
+# Install Headroom (bundles RTK)
+cargo install headroom
+
+# Start the local proxy (default port 8082)
+headroom proxy
+
+# Configure Claude Code to route through it
+```
+
+**`.claude/settings.local.json` snippet:**
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://localhost:8082"
+  }
+}
+```
+
+This is a **local-only** settings file (not committed). The
+`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` env var documented in
+[AI Agent Setup: Environment Variables](../AI_SETUP.md#environment-variables) continues to work alongside Headroom —
+Headroom compresses tokens in flight while autocompact still triggers at your configured threshold.
+
+## Caveman
+
+**Repo:** [github.com/JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman)
+
+Caveman is a Claude Code plugin that injects terse-style instructions at `SessionStart` and on
+**every `UserPromptSubmit` event**. It tells the model to prefer brevity: shorter responses,
+minimal prose, table-first formatting. Because it fires every turn, injected style survives
+autocompact and context drift — the model is reminded on each prompt, not just at session start.
+
+**Tipping-point:** adopt Caveman when you observe that Claude's response verbosity increases over
+a long session, or when you want a consistent terse baseline across all sessions without relying
+on ad-hoc prompting.
+
+**Caveman is complementary to `AGENTS.md`, not a replacement.** `AGENTS.md` is rich
+project-specific content (workflows, architecture, tooling rules) that is auto-loaded once per
+session. Caveman injects narrow style instructions on every turn. They target different things.
+Stacking is reasonable — but read the intensity trade-off table below before choosing a level.
+
+### Intensity levels
+
+| Level | What it enforces | Risk with project rules |
+| :--- | :--- | :--- |
+| `lite` | Terse phrasing, concise bullet points | Low — plays well with AGENTS.md; prose in issue bodies and PR descriptions is unaffected |
+| `full` | Short answers, table-first, minimal explanation | Medium — may shorten ADR rationale, PR descriptions, commit messages below template minimums |
+| `ultra` | Extreme brevity, single-sentence answers | High — likely to conflict with rules requiring structured long-form artefacts (issue bodies, ADR decisions) |
+
+**Recommendation: start with `lite`.** It reduces verbosity in conversational turns without
+clashing with template rules that require structured prose in artefacts. Move to `full` only
+after confirming your workload does not produce artefacts that need to meet a length standard.
+
+**Per-CLI applicability:**
+
+| CLI | Works? |
+| :--- | :--- |
+| Claude Code | Yes (native plugin system) |
+| Gemini CLI | No |
+| GitHub Copilot CLI | No |
+| Codex CLI | No |
+
+**Install and enable:**
+
+Follow the installation steps in the Caveman repo. Once installed, enable it at `lite` intensity
+in your local Claude Code settings:
+
+**`.claude/settings.local.json` snippet:**
+
+```json
+{
+  "plugins": {
+    "caveman": {
+      "intensity": "lite"
+    }
+  }
+}
+```
+
+This is a **local-only** file (not committed). Do not commit Caveman plugin config — intensity
+preference varies by operator and can conflict with other contributors' expectations.
+
+## Bash raw-tool ban (opt-in)
+
+This hook enforces what `AGENTS.md` already asks for: prefer native file tools (`Read`, `Grep`,
+`Glob`, `Edit`, `Write`) over their raw shell equivalents. When an agent defects to `Bash`, the
+raw output bypasses every other token-efficiency control and lands in context uncompressed.
+
+**What it blocks:**
+
+- Leading banned commands: `cat`, `head`, `tail`, `find`, `grep`, `rg`, `wc`
+
+Each block message names the offending command, suggests the native replacement, and reminds the
+agent about the escape hatch.
+
+**Native tool replacements:**
+
+| Blocked command | Use instead |
+| :--- | :--- |
+| `cat` / `head` / `tail` | `Read` |
+| `find` | `Glob` |
+| `grep` / `rg` | `Grep` |
+| `wc` | `Read` (then count in the result) |
+
+**Opt-in via `.claude/settings.local.json`:**
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/bash-ban-raw-tools.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This goes in `.claude/settings.local.json` (not committed) — each operator opts in individually.
+Do **not** add it to the committed `.claude/settings.json`.
+
+**Escape hatch:**
+
+```bash
+mkdir -p tmp/agents/claude && touch tmp/agents/claude/bash-raw-unlock
+```
+
+Run this from the project root. Allows all banned commands for 10 minutes. The file auto-expires —
+no cleanup needed. Useful when you need a one-off raw shell command without disabling the hook
+permanently.
+
+The unlock file is scoped to the project directory, so enabling the escape hatch in one project
+does not affect any other project running concurrently on the same machine. If you work across
+multiple projects, you must re-touch the file in each project root where you want raw commands
+allowed.
+
+**Why disabled by default:** humans share the repo. Raw shell commands are legitimate in human
+workflows. The hook is only beneficial when an AI agent is the primary operator of the terminal.
+Enable it locally for AI-heavy sessions; disable it when you are working interactively.
+
+**Related:** the always-on dangerous-command hook (committed in `.claude/settings.json`) is
+documented in [AI Command Blocking](command-blocking.md). The two hooks are complementary: the
+dangerous-command hook blocks security-relevant patterns for everyone; this hook enforces
+token-efficiency discipline only for operators who opt in.
+
+## Codebase Memory MCP gate (opt-in)
+
+The [Codebase Memory MCP server](https://github.com/DeusData/codebase-memory-mcp) (CBM) builds a
+tree-sitter knowledge graph of your repository and exposes it as MCP tools
+(`search_graph`, `trace_path`, `get_architecture`, `get_code_snippet`, `index_repository`,
+`detect_changes`). Structural queries — "where is function X defined?", "what calls module Y?" —
+cost orders of magnitude fewer tokens answered by the graph than by reading files directly.
+
+Without enforcement, models default to trained behaviour: `Read`/`Grep`/`Glob` on source files.
+The three hooks below close that loop.
+
+### Three-hook design
+
+| Hook | Event | What it does |
+| :--- | :--- | :--- |
+| `cbm-code-discovery-gate.py` | `PreToolUse` on `Read\|Grep\|Glob` | Blocks code-discovery on source files unless a CBM tool ran recently or the target is in the allow-list |
+| `cbm-mcp-marker.py` | `PostToolUse` on CBM tool prefix | Touches a sidecar marker file, opening a 120s window during which the gate passes through |
+| `cbm-session-reminder.py` | `SessionStart` on `compact\|resume\|clear` | Re-injects the CBM protocol into context so the model does not forget the discipline after autocompact |
+
+### Allow-list
+
+The gate passes through automatically for paths that CBM cannot help with:
+
+| Allow-list rule | What it covers |
+| :--- | :--- |
+| Extensions `.json .yaml .yml .md .toml .lock .txt .env .sh` | Config, docs, lockfiles |
+| Path contains `.claude/`, `CLAUDE.md`, `settings`, `hooks/` | Project metadata and hooks |
+| Path contains `tests/` or `_test.` | Test files |
+
+Source-code files (`.py`, `.ts`, `.js`, `.go`, etc.) are **not** in the allow-list. A
+`Grep`/`Glob` with no `path` argument (whole-repo search) is also always gated — that is exactly
+the case CBM's `search_graph` is optimised for.
+
+### Read-after-CBM workflow
+
+1. Agent calls a CBM tool (e.g. `mcp__codebase-memory__search_graph`).
+2. `cbm-mcp-marker.py` touches `/tmp/cbm-mcp-used-{ppid}` (scoped to the Claude Code session by
+   parent PID).
+3. Within 120 seconds, `Read`/`Grep`/`Glob` on source files passes through the gate.
+4. After 120 seconds the window closes — the next code-discovery call requires another CBM call
+   first.
+
+The 120-second window is deliberately short: long enough for a focused follow-up read, short
+enough to prevent the gate from becoming permanently open after a single CBM call at session start.
+
+### Setup
+
+**Prerequisites:** install and configure the CBM MCP server. Follow the upstream instructions at
+[github.com/DeusData/codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp). The
+hooks in this template assume the server is named `codebase-memory` in your MCP config.
+
+**Step 1** — Index the repository once:
+
+```bash
+# Inside a Claude Code session with CBM MCP wired:
+mcp__codebase-memory__index_repository
+```
+
+**Step 2** — Wire the three hooks in `.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Grep|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/cbm-code-discovery-gate.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "mcp__codebase-memory__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/cbm-mcp-marker.py"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/cbm-session-reminder.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This goes in `.claude/settings.local.json` (not committed) — each operator opts in individually.
+Do **not** add it to the committed `.claude/settings.json`.
+
+**Step 3** — Refresh the graph when the codebase changes materially:
+
+```bash
+mcp__codebase-memory__detect_changes   # check if refresh is needed
+mcp__codebase-memory__index_repository # re-index if needed
+```
+
+### Trust caveats
+
+CBM indexes the repository by parsing source files with tree-sitter. The resulting graph lives
+locally in whatever storage backend the CBM server is configured with. Key considerations:
+
+- **Graph staleness:** the graph reflects the codebase at the time of the last `index_repository`
+  call. After significant changes (new modules, major refactors), call `detect_changes` and
+  re-index before relying on graph results. The gate passes through regardless of graph freshness —
+  it enforces that a CBM tool *runs*, not that the graph is accurate.
+- **Server trust:** CBM reads your source files to build the graph. Apply the same due-diligence
+  you would to any tool that reads your codebase. Read the source and confirm no network egress
+  before using on sensitive or employer-owned codebases.
+- **MCP server name:** if your CBM server is configured under a different name than
+  `codebase-memory`, update the `PostToolUse` matcher (e.g. `mcp__my-cbm__.*`) to match. The
+  hook itself is tool-name-agnostic; only the matcher needs updating.
+
+**Why disabled by default:** CBM requires an external MCP server that each operator installs and
+configures separately. Wiring these hooks in committed settings would break every contributor who
+has not installed CBM.
+
+## context-mode MCP wrappers (opt-in)
+
+The [context-mode MCP](https://github.com/mksglu/context-mode) intercepts tool outputs, runs
+commands in a sandboxed environment, indexes the full output into a local BM25 knowledge base, and
+returns only a compact summary to the model. Claude can call `ctx_search` later to retrieve detail.
+This prevents large tool outputs — `pytest -v` over thousands of tests, `terraform plan`, verbose
+`kubectl describe` — from flooding the conversation context and consuming tokens until the next
+autocompact event.
+
+context-mode wires up via four lifecycle hooks (`PreToolUse`, `PostToolUse`, `PreCompact`,
+`SessionStart`), each invoking `context-mode hook claude-code <event>`. Without thin wrappers,
+operators must hand-wire all four — error-prone, and easy to omit the `PreCompact`/`SessionStart`
+events that handle index persistence across compaction cycles.
+
+### Five-hook design
+
+| Hook | Event | What it does |
+| :--- | :--- | :--- |
+| `context-mode-pretooluse.py` | `PreToolUse` (no matcher) | Forwards every PreToolUse event to the context-mode CLI for interception |
+| `context-mode-posttooluse.py` | `PostToolUse` (no matcher) | Forwards every PostToolUse event so outputs are indexed and summarised |
+| `context-mode-precompact.py` | `PreCompact` | Persists the BM25 index before autocompact so it survives context resets |
+| `context-mode-sessionstart.py` | `SessionStart` | Restores the index when a session resumes after compaction |
+| `context-mode-test-runner-reminder.py` | `PreToolUse` on `Bash` | Advisory only — reminds Claude to prefer `ctx_batch_execute` for test runs |
+
+Each forwarder uses `shutil.which("context-mode")` to detect non-installation and exits 0 silently.
+Non-installation is a no-op, not an error.
+
+### Setup
+
+**Prerequisites:** install the context-mode CLI and configure the MCP server. Follow the upstream
+instructions at [github.com/mksglu/context-mode](https://github.com/mksglu/context-mode).
+
+**Step 1** — Wire all five hooks in `.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/context-mode-pretooluse.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/context-mode-test-runner-reminder.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/context-mode-posttooluse.py"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/context-mode-precompact.py"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/context-mode-sessionstart.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This goes in `.claude/settings.local.json` (not committed) — each operator opts in individually.
+Do **not** add it to the committed `.claude/settings.json`.
+
+**Step 2** — Verify the wiring with a manual smoke test: install a fake `context-mode` shim that
+logs its argv to stderr, wire `context-mode-pretooluse.py` as above, trigger any tool call, and
+confirm stderr shows `context-mode hook claude-code PreToolUse` with the original stdin forwarded.
+
+### ctx_batch_execute workflow
+
+When `context-mode` MCP is active, prefer `ctx_batch_execute` for multi-command sequences (test +
+lint + typecheck) rather than running each command in a separate `Bash` call. `ctx_batch_execute`
+submits all commands together, indexes the combined output into the BM25 store, and returns a
+compact summary. Use `ctx_search` to retrieve specific detail from that summary on demand.
+
+This is most valuable for test runs on large projects where `pytest -v` output can easily exceed
+tens of thousands of lines.
+
+### Trust caveats
+
+context-mode claims to run commands in a sandboxed environment and maintain a local BM25 index with
+no network egress. Key considerations before adopting:
+
+- **Verify upstream:** read the source at [github.com/mksglu/context-mode](https://github.com/mksglu/context-mode)
+  to confirm no network egress before using on sensitive or employer-owned codebases.
+- **Local index:** the BM25 index lives on disk in whatever path context-mode configures. Treat it
+  with the same care as any file containing code excerpts.
+- **Index freshness:** the index reflects commands run since the last `SessionStart` restore. After
+  a session that skips the hooks, `ctx_search` may return stale or empty results.
+
+**Why disabled by default:** context-mode intercepts every tool call via `PreToolUse` and
+`PostToolUse` with no matcher restriction. Wiring these hooks in committed settings would add
+latency and context-mode dependency for every contributor regardless of whether they have installed
+the CLI.
+
+## Session-survival of project rules
+
+This section documents the **pattern** that Caveman uses, so you can apply it to any narrow rule
+that needs to survive long sessions — not just terse style.
+
+### The two injection mechanisms
+
+Claude Code offers two ways to get instructions in front of the model:
+
+| | Auto-load (`CLAUDE.md` / `AGENTS.md`) | Per-turn injection (`UserPromptSubmit` hook) |
+| :--- | :--- | :--- |
+| Loaded | Once at session start | Every user message |
+| Survives autocompact / context drift | No | Yes |
+| Best for | Rich, project-specific content | Narrow rules that "the model knows but forgets" |
+
+**Auto-load** is how this template ships `AGENTS.md` — comprehensive project context loaded once
+per session. It works well for the bulk of project rules. **The failure mode is drift**: after an
+autocompact event, or deep in a long conversation, the model may stop honoring a specific rule
+even though `AGENTS.md` is still nominally in context.
+
+**Per-turn injection** fires on every `UserPromptSubmit` event. It adds a small amount of text to
+every message, but that text is always present, always current, and always wins against drift.
+Caveman uses this mechanism for terse style. `cbm-session-reminder` (from the CBM tooling) uses
+it for protocol reminders — ensuring that CBM conventions are active throughout a session
+regardless of how many autocompact events have occurred.
+
+### When to use this pattern yourself
+
+The `UserPromptSubmit` hook is a reusable technique. If you have a narrow rule that you observe
+the model forgetting mid-session, wrapping it in a `UserPromptSubmit` hook is often more reliable
+than repeating it in `AGENTS.md`. Good candidates:
+
+- A naming convention the model tends to ignore late in sessions.
+- A formatting rule for a specific artefact type.
+- A reminder to use `doit` instead of raw `git`/`gh` for a particular class of operation.
+
+The hook lives in `.claude/settings.json` (committed) or `.claude/settings.local.json`
+(local-only). Keep injected text short — per-turn injection costs tokens on every message, so
+verbosity here works against the goal.
+
+### Per-stack rule files (third mechanism)
+
+A third application of the same pattern is **small per-stack rule files** imported into
+`.claude/CLAUDE.md` via the `@import` directive (for Claude) or into `GEMINI.md` via the `@`
+directive (for Gemini). Where per-turn injection is best for style rules that must survive every
+autocompact event, per-stack rule files are best for **narrow, domain-specific self-checks** that
+only apply when the agent is doing a specific class of work (code generation, database migrations,
+API contract changes, etc.).
+
+Each rule file is skill-gated, capped at 30 lines, and built from documented observed failures —
+not from generic advice. The template ships a commented-out `@import` placeholder in
+`.claude/CLAUDE.md` (which Claude Code honors as a no-op until uncommented). For Gemini, the
+template ships **no** `@`-import in `GEMINI.md` — Gemini's Memory Import Processor doesn't honor
+HTML comments and only supports literal file paths (not globs), so consumers add a literal
+`@./.gemini/rules/<name>.md` line per rule file when they author one.
+
+See [`.claude/rules/README.md`](../../../.claude/rules/README.md) and
+[`.gemini/rules/README.md`](../../../.gemini/rules/README.md) for the pattern, file structure, and
+a worked example.
+
+GitHub Copilot has a native equivalent: **`.github/instructions/NAME.instructions.md`** files with
+`applyTo:` YAML frontmatter for path-based gating. No import directive is needed — Copilot
+auto-discovers all `*.instructions.md` files in `.github/instructions/`. The body format (skill
+gate, numbered self-checks, observed-failures footer, ≤30 lines) is identical to the Claude and
+Gemini variants. The key contrast with those variants is the load mechanism:
+
+| CLI | Directory | Load mechanism |
+| :--- | :--- | :--- |
+| Claude Code | `.claude/rules/` | `@./rules/*.md` in `.claude/CLAUDE.md` |
+| Gemini CLI | `.gemini/rules/` | One `@./.gemini/rules/<name>.md` line per rule file in `GEMINI.md` (literal paths only) |
+| GitHub Copilot | `.github/instructions/` | Native auto-discovery (no directive needed) |
+| Codex CLI | `.agents/skills/<name>/` | `description:` frontmatter is the skill-gate trigger |
+
+Claude Code and Gemini CLI cannot read `.github/instructions/` files; this format is
+Copilot-native only. See [`.github/instructions/README.md`](../../../.github/instructions/README.md)
+for the full pattern and a worked example.
+
+Codex CLI uses a different mechanism: the `description:` field in a skill's YAML frontmatter acts
+as the skill-gate trigger — Codex auto-loads the skill when the task description matches. There is
+no `@import` directive. See [`.agents/skills/README.md`](../../../.agents/skills/README.md) for the
+full pattern and a worked example.
+
+## Related primitives in this template
+
+These are not add-ons (they ship with the template) but they interact with the tools above:
+
+- **`/checkpoint` and `/restore`** — session-state preservation commands. When a session is
+  about to hit its context limit, `/checkpoint` writes a portable state file and `/restore`
+  reconstructs context in a new session. Complements all three add-ons above. See
+  [Slash Commands and Workflows](slash-commands.md).
+- **Env-var defaults** — `ENABLE_PROMPT_CACHING_1H`, `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, and
+  `CLAUDE_CODE_SUBAGENT_MODEL` are already set via `.claude/settings.json`. Headroom and Caveman
+  layer on top of these defaults, not instead of them. See
+  [AI Agent Setup: Environment Variables](../AI_SETUP.md#environment-variables).
+- **PreCompact handoff hook** — ships with this template. Autocompact events now synthesize a
+  checkpoint automatically to `tmp/checkpoints/{inv_epoch}-auto-precompact.md` and the
+  `SessionStart` hook restores it into the next session, reducing context loss without any manual
+  `/checkpoint` invocation. See [Auto-Checkpoint and Session-Restore Hooks](auto-checkpoint-hook.md).
+## Out of scope
+
+- No code is shipped here. All three tools are external; install them from their respective repos.
+- Equivalent add-ons for Codex CLI and GitHub Copilot CLI. Most of these tools are Claude Code-specific. RTK is the notable exception with universal support.
+- Shipping tool configuration in this template's committed files. All snippets above go into
+  `.claude/settings.local.json` (not committed) to keep individual operator preferences local.

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -363,6 +363,7 @@ uv run pre-commit autoupdate
 | `no-commit-to-main` | Prevent direct commits to main branch |
 | `no-local-config` | Prevent committing local config files |
 | `protect-dynamic-version` | Protect `dynamic = ["version"]` in `pyproject.toml` |
+| `uv-lock-check` | Validate `uv.lock` is in sync with `pyproject.toml` when `pyproject.toml` is staged |
 
 **Commit-msg stage** (validates commit messages):
 

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -674,7 +674,7 @@ doit pr_merge --auto-close
 **Options:**
 - `--pr`: PR number to merge (defaults to PR for current branch)
 - `--delete-branch`: Delete the source branch after merge (default: `true`)
-- `--auto-close`: Close linked issues (parsed from `Addresses #XX` in the PR body) after a successful merge (default: `false`)
+- `--auto-close`: Close linked issues (parsed from `Addresses #XX` at the start of a line in the PR body) after a successful merge (default: `false`)
 
 ### `adr`
 
@@ -1138,6 +1138,7 @@ The following hooks run automatically on `git commit`:
 | `no-commit-to-main` | Prevent direct commits to main |
 | `no-local-config` | Prevent committing local config files |
 | `protect-dynamic-version` | Protect version configuration |
+| `uv-lock-check` | Validate `uv.lock` is in sync with `pyproject.toml` when `pyproject.toml` is staged |
 | `conventional-pre-commit` | Enforce conventional commit format |
 
 ### Dynamic Version Protection

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -422,6 +422,9 @@ In your PR body, use the `Addresses` keyword to link issues:
 |---------|--------|----------|
 | `Addresses #XX` | Included as `addresses #XX` in merge commit | PR relates to the issue |
 
+> [!NOTE]
+> The `Addresses #XX` keyword is case-sensitive and must be placed at the start of a line to be correctly parsed by `doit pr_merge`. Mid-sentence references or different capitalizations are ignored to prevent misattribution.
+
 **Example PR body:**
 ```markdown
 ## Summary

--- a/tests/template/test_doit_git.py
+++ b/tests/template/test_doit_git.py
@@ -1,0 +1,47 @@
+"""Tests for tools/doit/git.py task wiring.
+
+Verifies that ``task_commit``, ``task_bump``, and ``task_changelog`` gate
+their ``cz`` invocations on ``uv pip show commitizen`` (via
+``install_check_or_skip``) so real failures — pre-commit hook rejections,
+tag/version bump failures, changelog generation failures — propagate
+instead of being swallowed by the legacy ``|| echo 'not installed'`` pattern.
+
+Addresses issue #527.
+"""
+
+from __future__ import annotations
+
+from tools.doit.git import task_bump, task_changelog, task_commit
+
+
+class TestGitTaskGates:
+    """Each git task gates ``cz`` via ``uv pip show commitizen``.
+
+    The package name is ``commitizen`` (CLI is ``cz``). All three tasks
+    share the same gating package; the underlying ``cz`` subcommand differs.
+    """
+
+    def test_commit_gates_on_commitizen_package(self) -> None:
+        action = task_commit()["actions"][0]
+        assert isinstance(action, str)
+        assert "uv pip show commitizen" in action
+        assert "commitizen not installed. Run: uv sync" in action
+        assert "uv run cz commit" in action
+        # Bug-fix invariant: the bare-swallow pattern must be gone.
+        assert "|| echo 'commitizen not installed" not in action
+
+    def test_bump_gates_on_commitizen_package(self) -> None:
+        action = task_bump()["actions"][0]
+        assert isinstance(action, str)
+        assert "uv pip show commitizen" in action
+        assert "commitizen not installed. Run: uv sync" in action
+        assert "uv run cz bump" in action
+        assert "|| echo 'commitizen not installed" not in action
+
+    def test_changelog_gates_on_commitizen_package(self) -> None:
+        action = task_changelog()["actions"][0]
+        assert isinstance(action, str)
+        assert "uv pip show commitizen" in action
+        assert "commitizen not installed. Run: uv sync" in action
+        assert "uv run cz changelog" in action
+        assert "|| echo 'commitizen not installed" not in action

--- a/tests/test_statusline_claude_usage.py
+++ b/tests/test_statusline_claude_usage.py
@@ -1,0 +1,251 @@
+"""Tests for tools/statusline/claude-usage.sh opt-in helper."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# The helper is a bash script targeting Linux/macOS; the Windows GitHub Actions
+# runner's `bash` resolves to wsl.exe (which has no installed distribution),
+# so subprocess invocations cannot exercise the real shell behavior.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash helper is Linux/macOS only; Windows runner has no usable bash",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "tools" / "statusline" / "claude-usage.sh"
+STATUSLINE = REPO_ROOT / ".claude" / "statusline-command.sh"
+
+_STATUSLINE_INPUT = json.dumps(
+    {
+        "model": {"display_name": "Claude"},
+        "cwd": "/tmp",
+        "transcript_path": "",
+        "context_window": {"context_window_size": 200000},
+    }
+)
+
+# ISO timestamps far in the future so the test is timezone-agnostic for the date
+# part; only HHMM can vary by local TZ offset and that is accepted by the regex.
+_FH_RESETS_AT = "2099-06-15T18:00:00+00:00"
+_WK_RESETS_AT = "2099-06-16T20:00:00+00:00"
+
+
+def _make_env(tmp_path: Path) -> dict[str, str]:
+    """Build a minimal, network-safe environment for subprocess calls."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    creds_dir = tmp_path / "creds"
+    creds_dir.mkdir()
+    return {
+        "HOME": str(tmp_path),
+        "XDG_CACHE_HOME": str(cache_dir),
+        "CLAUDE_CONFIG_DIR": str(creds_dir),
+        "PATH": os.environ["PATH"],
+    }
+
+
+def test_script_exists_and_executable() -> None:
+    """Helper script must exist at the expected path and be executable."""
+    assert SCRIPT.exists(), f"Script not found: {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), f"Script not executable: {SCRIPT}"
+
+
+def test_script_syntax_valid() -> None:
+    """bash -n must report no syntax errors."""
+    result = subprocess.run(
+        ["bash", "-n", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0, f"Syntax error:\n{result.stderr}"
+
+
+def test_emits_fallback_when_credentials_missing(tmp_path: Path) -> None:
+    """No .credentials.json and no cache -> output is literal '?', exit 0."""
+    env = _make_env(tmp_path)
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def test_uses_fresh_cache_skips_network(tmp_path: Path) -> None:
+    """Pre-seeded fresh cache is parsed and returned without hitting the network."""
+    env = _make_env(tmp_path)
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    payload = {
+        "five_hour": {"utilization": 42.7, "resets_at": _FH_RESETS_AT},
+        "seven_day": {"utilization": 7.3, "resets_at": _WK_RESETS_AT},
+    }
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+    # Ensure mtime is current (fresh cache)
+    now = time.time()
+    os.utime(cache_file, (now, now))
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    output = result.stdout.strip()
+    # Format: 5h:42%@HHMM wk:7%@aaa-HHMM  (HHMM and aaa vary by runner TZ)
+    assert re.search(r"5h:42%@\d{4} wk:7%@[A-Za-z]{3}-\d{4}", output), (
+        f"Unexpected output: {output!r}"
+    )
+
+
+def test_emits_fallback_on_malformed_cache(tmp_path: Path) -> None:
+    """Fresh cache that contains invalid JSON emits '?'."""
+    env = _make_env(tmp_path)
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    cache_file.write_text("not-json", encoding="utf-8")
+    now = time.time()
+    os.utime(cache_file, (now, now))
+    # No credentials file either, so the script won't fall through to the network
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def test_emits_fallback_when_token_field_missing(tmp_path: Path) -> None:
+    """Credentials file present but missing claudeAiOauth.accessToken -> '?'."""
+    env = _make_env(tmp_path)
+    creds_file = Path(env["CLAUDE_CONFIG_DIR"]) / ".credentials.json"
+    creds_file.write_text(json.dumps({}), encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def test_emits_fallback_when_resets_at_missing(tmp_path: Path) -> None:
+    """Fresh cache with utilization but no resets_at fields emits '?'."""
+    env = _make_env(tmp_path)
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    payload = {
+        "five_hour": {"utilization": 42.7},
+        "seven_day": {"utilization": 7.3},
+    }
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+    now = time.time()
+    os.utime(cache_file, (now, now))
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def test_emits_fallback_when_resets_at_malformed(tmp_path: Path) -> None:
+    """Fresh cache with unparsable resets_at string emits '?'."""
+    env = _make_env(tmp_path)
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    payload = {
+        "five_hour": {"utilization": 42.7, "resets_at": "not-a-date"},
+        "seven_day": {"utilization": 7.3, "resets_at": "also-not-a-date"},
+    }
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+    now = time.time()
+    os.utime(cache_file, (now, now))
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def _seed_fresh_cache(env: dict[str, str]) -> None:
+    """Pre-write a parseable, fresh cache so the helper short-circuits curl."""
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    payload = {
+        "five_hour": {"utilization": 42.7, "resets_at": _FH_RESETS_AT},
+        "seven_day": {"utilization": 7.3, "resets_at": _WK_RESETS_AT},
+    }
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+    now = time.time()
+    os.utime(cache_file, (now, now))
+
+
+def test_statusline_invokes_helper_when_env_set(tmp_path: Path) -> None:
+    """With CLAUDE_USAGE_STATUSLINE=1 and a fresh cache, statusline shows usage."""
+    env = _make_env(tmp_path)
+    env["CLAUDE_USAGE_STATUSLINE"] = "1"
+    env["CLAUDE_PROJECT_DIR"] = str(REPO_ROOT)
+    _seed_fresh_cache(env)
+
+    result = subprocess.run(
+        ["bash", str(STATUSLINE)],
+        input=_STATUSLINE_INPUT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    # Both bucket labels must appear; exact times vary by runner TZ.
+    # The wrapper injects a middle-dot separator between gauges.
+    assert "5h:" in result.stdout
+    assert "wk:" in result.stdout
+    assert "7d:" not in result.stdout
+    assert " · " in result.stdout
+
+
+def test_statusline_skips_helper_when_env_unset(tmp_path: Path) -> None:
+    """Without CLAUDE_USAGE_STATUSLINE, statusline never invokes the helper."""
+    env = _make_env(tmp_path)
+    env["CLAUDE_PROJECT_DIR"] = str(REPO_ROOT)
+    # Fresh cache exists, so a bug that skipped the env check would still surface usage.
+    _seed_fresh_cache(env)
+
+    result = subprocess.run(
+        ["bash", str(STATUSLINE)],
+        input=_STATUSLINE_INPUT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "5h:" not in result.stdout
+    assert "wk:" not in result.stdout

--- a/tools/statusline/claude-usage.sh
+++ b/tools/statusline/claude-usage.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Opt-in Claude Max usage helper for statusline display.
+# Outputs: 5h:N%@HHMM wk:N%@aaa-HHMM on success, or literal ? on any failure.
+# Wire into .claude/statusline-command.sh manually — not called by default.
+#
+# Requirements: curl, jq, python3, active Claude Code OAuth login
+# See: docs/development/ai/statusline.md#opt-in-claude-max-usage-display
+
+# Cache TTL in seconds
+MAX_AGE=60
+
+CREDS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CREDS_FILE="$CREDS_DIR/.credentials.json"
+CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/claude-usage.json"
+
+# Format a single ISO timestamp into local-timezone compact time.
+# Usage: _fmt_ts <iso_string> <strftime_format>
+# Returns empty string on failure.
+_fmt_ts() {
+    local iso="$1"
+    local fmt="$2"
+    python3 -c "
+from datetime import datetime
+import sys
+try:
+    dt = datetime.fromisoformat(sys.argv[1]).astimezone()
+    print(dt.strftime(sys.argv[2]))
+except Exception:
+    sys.exit(1)
+" "$iso" "$fmt" 2>/dev/null
+}
+
+# Parse a usage JSON file and emit the formatted statusline segment.
+# Usage: parse_usage <json_file>
+# On success: prints  5h:N%@HHMM wk:N%@aaa-HHMM  and returns 0.
+# On any failure: prints ? and returns 1.
+parse_usage() {
+    local file="$1"
+    # Extract the four fields as tab-separated; 'empty' if any field is missing.
+    local record
+    record=$(jq -r '
+        if (.five_hour.utilization != null) and (.five_hour.resets_at != null) and
+           (.seven_day.utilization != null) and (.seven_day.resets_at != null)
+        then [
+            (.five_hour.utilization | floor | tostring),
+            .five_hour.resets_at,
+            (.seven_day.utilization | floor | tostring),
+            .seven_day.resets_at
+        ] | join("\t")
+        else empty
+        end
+    ' "$file" 2>/dev/null)
+
+    if [[ -z "$record" ]]; then
+        echo "?"
+        return 1
+    fi
+
+    IFS=$'\t' read -r fh_pct fh_ts wk_pct wk_ts <<< "$record"
+
+    local fh_time wk_time
+    fh_time=$(_fmt_ts "$fh_ts" "%H%M")
+    if [[ -z "$fh_time" ]]; then
+        echo "?"
+        return 1
+    fi
+
+    wk_time=$(_fmt_ts "$wk_ts" "%a-%H%M")
+    if [[ -z "$wk_time" ]]; then
+        echo "?"
+        return 1
+    fi
+
+    echo "5h:${fh_pct}%@${fh_time} wk:${wk_pct}%@${wk_time}"
+    return 0
+}
+
+# Check cache freshness first — avoids a network call and a token read on every invocation
+if [[ -f "$CACHE" ]]; then
+    if stat -f %m "$CACHE" >/dev/null 2>&1; then
+        cache_mtime=$(stat -f %m "$CACHE" 2>/dev/null)
+    else
+        cache_mtime=$(stat -c %Y "$CACHE" 2>/dev/null)
+    fi
+    if [[ -n "$cache_mtime" ]] && [[ "$cache_mtime" =~ ^[0-9]+$ ]]; then
+        now=$(date +%s)
+        age=$((now - cache_mtime))
+        if [[ $age -lt $MAX_AGE ]]; then
+            parse_usage "$CACHE"
+            exit 0
+        fi
+    fi
+fi
+
+# Read OAuth token from credentials
+token=$(jq -r '.claudeAiOauth.accessToken // empty' "$CREDS_FILE" 2>/dev/null)
+if [[ -z "$token" ]]; then
+    echo "?"
+    exit 0
+fi
+
+# Fetch fresh data
+response=$(curl -sf --max-time 5 \
+    -H "Authorization: Bearer $token" \
+    -H "anthropic-beta: oauth-2025-04-20" \
+    "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+if [[ -z "$response" ]]; then
+    echo "?"
+    exit 0
+fi
+
+# Save to cache and parse
+echo "$response" > "$CACHE" 2>/dev/null
+parse_usage "$CACHE"


### PR DESCRIPTION
## Description

**PR 4 of 4 (final)** for the pyproject-template sync (`170df8c9` → `e3d32ea`). Completes the sync: remaining documentation, the statusline add-on, two new tests, and the recorded sync point. After this merges, `manage.py check` reports **no differences** beyond the intentional `sync-exclude.toml` divergences, and **issue #64 can be closed**.

**Series:** PR 1 (#65, doit/deps/CI) · PR 2 (#66, hooks) · PR 3 (#67, commands/skills) · **PR 4 (this, docs/statusline/sync-mark)**.

Addresses #64

## Changes Made

### Docs — synced to template (10)
`docs/decisions/9006-merge-gate-workflow.md`, `docs/decisions/9009-use-pre-commit-hooks-for-quality-gates.md` (ADR text refreshes), `docs/development/ai/command-blocking.md`, `docs/development/ai/first-5-minutes.md`, `docs/development/AI_SETUP.md`, `docs/development/ai/slash-commands.md`, `docs/development/ai/statusline.md`, `docs/development/ci-cd-testing.md`, `docs/development/doit-tasks-reference.md`, `docs/development/release-and-automation.md`. This includes the full content rewrite of the docs that PR 3 only touched minimally (resolving the stale command references noted in PR 3).

### Docs — new (3)
`docs/development/ai/auto-checkpoint-hook.md`, `docs/development/ai/lsp-tool.md`, `docs/development/ai/token-efficiency-add-ons.md` (the enablement guide for the opt-in hooks shipped in PR 2).

### Statusline
`tools/statusline/claude-usage.sh` (new) and `.claude/statusline-command.sh` (adds `C_DIM`/`C_PCT`/`C_TIME` colors + the opt-in `CLAUDE_USAGE_STATUSLINE` block).

### Tests (2 new)
`tests/template/test_doit_git.py`, `tests/test_statusline_claude_usage.py`.

### Gap files missed by the per-PR scoping (5)
While verifying the end state, `manage.py check` surfaced 5 files that were genuine drift **at e3d32ea** (template `main` is still exactly `e3d32ea`, verified) but fell outside the explicit dir lists of PRs 1–3. Closing them here so the recorded sync point is honest:
- `.claude/agents/implement-worker.md` — command-rename update (`/implement`→`/claude:implement`, `/finalize`→`/ghi-finalize`); no project divergence.
- `.claude/rules/README.md`, `.gemini/rules/README.md`, `.github/instructions/README.md`, `.gemini/policies/developer.toml` — new template config files (copied verbatim, no placeholders).

### Sync point
`.config/pyproject_template/settings.toml` now records `commit = e3d32ea0e434cf373a85bde5f2d535aeb9393b99` / `commit_date = 2026-06-02`.

## Testing

- [x] `doit check` passes in full (format, lint, type_check, security, audit, spell_check, tests — 1260+ passing)
- [x] New tests pass (`test_doit_git.py`, `test_statusline_claude_usage.py`)
- [x] `manage.py check` reports **no differences** (only the 56 `sync-exclude.toml` files skipped)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

- **No ADR required:** chore/template-sync; ADRs 9006/9009 received template text refreshes only (no new decisions).
- **Closes out the sync:** with this PR merged, the project is fully aligned to template `e3d32ea` except the deliberate `sync-exclude.toml` divergences. **Issue #64 should be closed** after merge.
