### PR TITLE
feat: expose proxy/transport configuration on OPNsenseClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,52 @@ opnsense-openapi generate <version>
 
 See [Generated Client Usage](docs/usage/generated-client.md) for complete documentation.
 
+### Accessing OPNsense Through an SSH Tunnel
+
+When the OPNsense instance is only reachable through a bastion host, use an SSH
+SOCKS proxy or a local port-forward.
+
+**Option A — SOCKS proxy (`ssh -D`)**: remote DNS, best when the OPNsense
+hostname only resolves inside the remote network:
+
+```bash
+# In a separate terminal, open the SOCKS proxy:
+ssh -D 1080 -N user@bastion
+```
+
+```python
+# Install SOCKS support first:
+# pip install "opnsense-openapi[socks]"
+from opnsense_openapi import OPNsenseClient
+
+client = OPNsenseClient(
+    base_url="https://opnsense.internal",
+    api_key="your-key",
+    api_secret="your-secret",
+    proxy="socks5h://127.0.0.1:1080",  # 'socks5h' resolves DNS through the tunnel
+    verify_ssl=False,
+)
+```
+
+**Option B — local port-forward (`ssh -L`)**: no proxy needed, point
+`base_url` directly at the forwarded port:
+
+```bash
+# Forward local port 8443 to opnsense:443 through the bastion:
+ssh -L 8443:opnsense.internal:443 -N user@bastion
+```
+
+```python
+from opnsense_openapi import OPNsenseClient
+
+client = OPNsenseClient(
+    base_url="https://localhost:8443",
+    api_key="your-key",
+    api_secret="your-secret",
+    verify_ssl=False,
+)
+```
+
 ## CLI Commands
 
 ### Complete Setup (Recommended)

--- a/docs/usage/generated-client.md
+++ b/docs/usage/generated-client.md
@@ -267,6 +267,128 @@ except Exception as e:
         raise
 ```
 
+## Proxy / Transport Configuration
+
+`OPNsenseClient` exposes a full-passthrough surface for httpx networking options.
+All new parameters default to the existing behaviour, so there is no breaking
+change.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `proxy` | `str \| httpx.Proxy \| None` | `None` | Proxy URL for all requests |
+| `trust_env` | `bool` | `True` | Honour proxy env vars (`HTTP_PROXY`, etc.) |
+| `transport` | `httpx.BaseTransport \| None` | `None` | Custom transport (overrides proxy/mounts/verify) |
+| `mounts` | `dict[str, httpx.BaseTransport \| None] \| None` | `None` | Per-URL-pattern transport map |
+| `session` | `httpx.Client \| None` | `None` | Pre-built httpx client (caller retains ownership) |
+
+### httpx Precedence Rules
+
+1. A custom `transport` overrides `proxy`, `mounts`, and `verify_ssl`.
+2. `proxy` is shorthand for mounting a transport on the `all://` pattern.
+3. If both `proxy` and `mounts` are given, httpx merges them; explicit `mounts`
+   entries win for their URL patterns.
+
+### SSH Tunnel — SOCKS Proxy (`ssh -D`)
+
+Use `socks5h://` when the OPNsense hostname only resolves inside the remote
+network (the `h` suffix delegates DNS resolution to the SOCKS server):
+
+```bash
+# Install SOCKS support (pulls in socksio via httpx):
+pip install "opnsense-openapi[socks]"
+
+# Open the SOCKS proxy in a separate terminal:
+ssh -D 1080 -N user@bastion
+```
+
+```python
+from opnsense_openapi import OPNsenseClient
+
+client = OPNsenseClient(
+    base_url="https://opnsense.internal",
+    api_key="your-key",
+    api_secret="your-secret",
+    proxy="socks5h://127.0.0.1:1080",  # remote DNS through the tunnel
+    verify_ssl=False,
+)
+```
+
+Use `socks5://` (no `h`) when the OPNsense hostname resolves locally, so DNS
+lookup happens on the client side before the connection is forwarded.
+
+If `socksio` is not installed, httpx raises a clear `ImportError` explaining the
+missing dependency.
+
+### SSH Tunnel — Local Port-Forward (`ssh -L`)
+
+No proxy is needed; point `base_url` at the forwarded port directly:
+
+```bash
+ssh -L 8443:opnsense.internal:443 -N user@bastion
+```
+
+```python
+from opnsense_openapi import OPNsenseClient
+
+client = OPNsenseClient(
+    base_url="https://localhost:8443",
+    api_key="your-key",
+    api_secret="your-secret",
+    verify_ssl=False,
+)
+```
+
+### Custom Transport (e.g. for Testing)
+
+```python
+import httpx
+from opnsense_openapi import OPNsenseClient
+
+def handler(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(200, json={"product_version": "25.1"})
+
+client = OPNsenseClient(
+    base_url="https://opnsense.local",
+    api_key="key",
+    api_secret="secret",
+    transport=httpx.MockTransport(handler),
+    auto_detect_version=False,
+)
+result = client.get("core", "firmware", "info")
+# result == {"product_version": "25.1"}
+```
+
+### Injected Session
+
+Inject a pre-configured `httpx.Client` when you need to share a session across
+multiple clients or manage its lifecycle yourself:
+
+```python
+import httpx
+from opnsense_openapi import OPNsenseClient
+
+shared_session = httpx.Client(verify=False, timeout=60)
+
+client = OPNsenseClient(
+    base_url="https://opnsense.local",
+    api_key="key",
+    api_secret="secret",
+    session=shared_session,
+    auto_detect_version=False,
+)
+
+# OPNsenseClient applies auth/headers onto shared_session but does NOT close it.
+# The caller is responsible for closing shared_session when done.
+client.close()          # no-op for the session
+shared_session.close()  # caller closes explicitly
+```
+
+**Important:** When `session` is provided, `verify_ssl`, `timeout`, `proxy`,
+`trust_env`, `transport`, and `mounts` are all **ignored** — they cannot be
+retrofitted onto an existing `httpx.Client`.
+
 ## Legacy Wrapper (Still Supported)
 
 The dynamic wrapper still works for backwards compatibility:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,15 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "httpx>=0.27.0",
+    "httpx>=0.28.0",
     "typer>=0.9.0",
     "jsonschema>=4.21.0",
 ]
 
 [project.optional-dependencies]
+socks = [
+    "httpx[socks]>=0.28.0",
+]
 dev = [
     "doit>=0.36.0",
     "pytest>=9.0.3",

--- a/src/opnsense_openapi/client/base.py
+++ b/src/opnsense_openapi/client/base.py
@@ -192,6 +192,11 @@ class OPNsenseClient:
         auto_detect_version: bool = True,
         auth: Any = None,
         headers: dict[str, str] | None = None,
+        proxy: str | httpx.Proxy | None = None,
+        trust_env: bool = True,
+        transport: httpx.BaseTransport | None = None,
+        mounts: dict[str, httpx.BaseTransport | None] | None = None,
+        session: httpx.Client | None = None,
     ) -> None:
         """Initialize OPNsense API client.
 
@@ -207,6 +212,44 @@ class OPNsenseClient:
                                 detect version from server
             auth: Custom httpx auth object (overrides api_key/api_secret)
             headers: Custom headers to include in requests
+            proxy: Proxy URL or ``httpx.Proxy`` object for all requests.  A plain
+                string such as ``"http://proxy:8080"`` or a SOCKS URL such as
+                ``"socks5h://127.0.0.1:1080"`` are both accepted.  SOCKS support
+                requires the ``opnsense-openapi[socks]`` extra (``pip install
+                opnsense-openapi[socks]``); httpx raises a clear ``ImportError``
+                if ``socksio`` is absent.
+                Ignored when ``session`` is provided (cannot be retrofitted onto
+                an existing ``httpx.Client``).
+            trust_env: Whether to honour proxy settings from environment variables
+                (``HTTP_PROXY``, ``HTTPS_PROXY``, ``ALL_PROXY``, ``NO_PROXY``).
+                Defaults to ``True`` (current behaviour).  Set to ``False`` to
+                disable env-var proxies.
+                Ignored when ``session`` is provided.
+            transport: Custom ``httpx.BaseTransport`` for all requests.  Takes
+                precedence over ``proxy``, ``mounts``, and ``verify`` — httpx
+                applies its own resolution order.
+                ``httpx.MockTransport`` is useful in tests.
+                Ignored when ``session`` is provided.
+            mounts: Per-URL-pattern transport map passed directly to
+                ``httpx.Client``.  ``proxy`` is shorthand for an ``all://`` mount;
+                if both are given httpx merges them (explicit mount entries win for
+                their patterns).
+                Ignored when ``session`` is provided.
+            session: Pre-built ``httpx.Client`` to use instead of creating a new
+                one.  When provided, ``verify_ssl``, ``timeout``, ``proxy``,
+                ``trust_env``, ``transport``, and ``mounts`` are all **ignored**
+                (they cannot be retrofitted onto an existing client).  Auth and
+                headers are applied onto the injected session only when they carry
+                non-empty values.  The caller retains ownership: ``close()`` and
+                the context-manager exit do **not** close an injected session.
+
+        httpx precedence rules (when building a new client):
+            1. A custom ``transport`` overrides ``proxy``, ``mounts``, and
+               ``verify`` — httpx routes every request through it directly.
+            2. ``proxy`` is shorthand for mounting a single transport on the
+               ``all://`` pattern.
+            3. If both ``proxy`` and ``mounts`` are given, httpx merges them;
+               explicit ``mounts`` entries win for their URL patterns.
         """
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key or ""
@@ -219,13 +262,27 @@ class OPNsenseClient:
         if client_auth is None and api_key and api_secret:
             client_auth = (api_key, api_secret)
 
-        self._client: httpx.Client = httpx.Client(
-            auth=client_auth,
-            headers=headers,
-            verify=verify_ssl,
-            timeout=timeout,
-            follow_redirects=True,
-        )
+        if session is not None:
+            # Caller-owned session: apply credentials/headers only when provided.
+            self._client = session
+            self._owns_client = False
+            if client_auth is not None:
+                self._client.auth = client_auth
+            if headers:
+                self._client.headers.update(headers)
+        else:
+            self._client = httpx.Client(
+                auth=client_auth,
+                headers=headers,
+                verify=verify_ssl,
+                timeout=timeout,
+                proxy=proxy,
+                trust_env=trust_env,
+                transport=transport,
+                mounts=mounts,
+                follow_redirects=True,
+            )
+            self._owns_client = True
 
         # OpenAPI wrapper (lazily initialized)
         self._openapi: APIWrapper | None = None
@@ -320,8 +377,14 @@ class OPNsenseClient:
             raise APIResponseError(f"Invalid JSON response from {url}: {e}", response.text) from e
 
     def close(self) -> None:
-        """Close the HTTP client."""
-        self._client.close()
+        """Close the HTTP client.
+
+        Only closes the underlying ``httpx.Client`` when this instance owns it
+        (i.e. no pre-built ``session`` was injected).  A caller-owned session is
+        left open so the caller can reuse or close it on their own schedule.
+        """
+        if self._owns_client:
+            self._client.close()
 
     def __enter__(self) -> OPNsenseClient:
         """Context manager entry."""

--- a/tests/test_client_base.py
+++ b/tests/test_client_base.py
@@ -473,3 +473,215 @@ def test_context_manager_closes_on_exit() -> None:
     ):
         pass
     inner.close.assert_called_once()
+
+
+# --------------- proxy / transport / session passthrough ----------------------
+
+
+def test_proxy_threaded_into_httpx_client() -> None:
+    """``proxy`` is forwarded to the ``httpx.Client`` constructor."""
+    inner = MagicMock(spec=httpx.Client)
+    with patch("httpx.Client", return_value=inner) as mock_cls:
+        OPNsenseClient(
+            base_url="https://opnsense.local",
+            api_key="key",
+            api_secret="secret",
+            auto_detect_version=False,
+            proxy="socks5h://127.0.0.1:1080",
+        )
+    assert mock_cls.call_args.kwargs["proxy"] == "socks5h://127.0.0.1:1080"
+
+
+def test_trust_env_false_threaded_into_httpx_client() -> None:
+    """Explicit ``trust_env=False`` is forwarded to the ``httpx.Client`` constructor."""
+    inner = MagicMock(spec=httpx.Client)
+    with patch("httpx.Client", return_value=inner) as mock_cls:
+        OPNsenseClient(
+            base_url="https://opnsense.local",
+            api_key="key",
+            api_secret="secret",
+            auto_detect_version=False,
+            trust_env=False,
+        )
+    assert mock_cls.call_args.kwargs["trust_env"] is False
+
+
+def test_trust_env_default_is_true() -> None:
+    """Default ``trust_env`` is ``True`` (preserves current env-var proxy behaviour)."""
+    inner = MagicMock(spec=httpx.Client)
+    with patch("httpx.Client", return_value=inner) as mock_cls:
+        OPNsenseClient(
+            base_url="https://opnsense.local",
+            api_key="key",
+            api_secret="secret",
+            auto_detect_version=False,
+        )
+    assert mock_cls.call_args.kwargs["trust_env"] is True
+
+
+def test_transport_threaded_into_httpx_client() -> None:
+    """``transport`` is forwarded to the ``httpx.Client`` constructor."""
+    inner = MagicMock(spec=httpx.Client)
+    mock_transport = MagicMock(spec=httpx.BaseTransport)
+    with patch("httpx.Client", return_value=inner) as mock_cls:
+        OPNsenseClient(
+            base_url="https://opnsense.local",
+            api_key="key",
+            api_secret="secret",
+            auto_detect_version=False,
+            transport=mock_transport,
+        )
+    assert mock_cls.call_args.kwargs["transport"] is mock_transport
+
+
+def test_mounts_threaded_into_httpx_client() -> None:
+    """``mounts`` is forwarded to the ``httpx.Client`` constructor."""
+    inner = MagicMock(spec=httpx.Client)
+    mock_transport = MagicMock(spec=httpx.BaseTransport)
+    mounts_map: dict[str, httpx.BaseTransport | None] = {"https://opnsense.local": mock_transport}
+    with patch("httpx.Client", return_value=inner) as mock_cls:
+        OPNsenseClient(
+            base_url="https://opnsense.local",
+            api_key="key",
+            api_secret="secret",
+            auto_detect_version=False,
+            mounts=mounts_map,
+        )
+    assert mock_cls.call_args.kwargs["mounts"] is mounts_map
+
+
+def test_defaults_preserve_proxy_transport_mounts_none() -> None:
+    """Default invocation passes ``proxy=None``, ``transport=None``, ``mounts=None``."""
+    inner = MagicMock(spec=httpx.Client)
+    with patch("httpx.Client", return_value=inner) as mock_cls:
+        OPNsenseClient(
+            base_url="https://opnsense.local",
+            api_key="key",
+            api_secret="secret",
+            auto_detect_version=False,
+        )
+    kwargs = mock_cls.call_args.kwargs
+    assert kwargs["proxy"] is None
+    assert kwargs["transport"] is None
+    assert kwargs["mounts"] is None
+    assert kwargs["trust_env"] is True
+
+
+def test_session_injection_uses_provided_client() -> None:
+    """When ``session`` is provided, ``_client`` is set to it; ``httpx.Client`` is not called."""
+    injected = MagicMock(spec=httpx.Client)
+    injected.headers = MagicMock()
+    with patch("httpx.Client") as mock_cls:
+        client = OPNsenseClient(
+            base_url="https://opnsense.local",
+            auto_detect_version=False,
+            session=injected,
+        )
+    mock_cls.assert_not_called()
+    assert client._client is injected
+
+
+def test_session_injection_applies_auth_when_provided() -> None:
+    """Auth is applied to an injected session when ``api_key``/``api_secret`` are given."""
+    injected = MagicMock(spec=httpx.Client)
+    injected.headers = MagicMock()
+    OPNsenseClient(
+        base_url="https://opnsense.local",
+        api_key="k",
+        api_secret="s",
+        auto_detect_version=False,
+        session=injected,
+    )
+    assert injected.auth == ("k", "s")
+
+
+def test_session_injection_applies_headers_when_provided() -> None:
+    """Headers are merged onto an injected session when ``headers`` is truthy."""
+    injected = MagicMock(spec=httpx.Client)
+    injected.headers = MagicMock()
+    custom_headers = {"X-Custom": "value"}
+    OPNsenseClient(
+        base_url="https://opnsense.local",
+        auto_detect_version=False,
+        session=injected,
+        headers=custom_headers,
+    )
+    injected.headers.update.assert_called_once_with(custom_headers)
+
+
+def test_session_injection_leaves_session_untouched_without_credentials() -> None:
+    """An injected session without auth or headers is left completely untouched."""
+    injected = MagicMock(spec=httpx.Client)
+    injected.headers = MagicMock()
+    OPNsenseClient(
+        base_url="https://opnsense.local",
+        auto_detect_version=False,
+        session=injected,
+    )
+    # auth should not be set; headers.update should not be called
+    assert not hasattr(injected, "_auth_set_by_test")
+    injected.headers.update.assert_not_called()
+
+
+def test_close_does_not_close_injected_session() -> None:
+    """``close()`` must NOT close an injected (caller-owned) session."""
+    injected = MagicMock(spec=httpx.Client)
+    injected.headers = MagicMock()
+    client = OPNsenseClient(
+        base_url="https://opnsense.local",
+        auto_detect_version=False,
+        session=injected,
+    )
+    client.close()
+    injected.close.assert_not_called()
+
+
+def test_context_manager_does_not_close_injected_session() -> None:
+    """Exiting the context manager must NOT close an injected session."""
+    injected = MagicMock(spec=httpx.Client)
+    injected.headers = MagicMock()
+    with OPNsenseClient(
+        base_url="https://opnsense.local",
+        auto_detect_version=False,
+        session=injected,
+    ):
+        pass
+    injected.close.assert_not_called()
+
+
+def test_close_closes_owned_client() -> None:
+    """``close()`` closes the client when it was built internally (no ``session``)."""
+    inner = MagicMock(spec=httpx.Client)
+    with patch("httpx.Client", return_value=inner):
+        client = OPNsenseClient(
+            base_url="https://opnsense.local",
+            api_key="key",
+            api_secret="secret",
+            auto_detect_version=False,
+        )
+    client.close()
+    inner.close.assert_called_once()
+
+
+def test_functional_mock_transport_roundtrip(
+    mock_httpx_response: Callable[..., httpx.Response],
+) -> None:
+    """A ``transport=httpx.MockTransport(...)`` wires through to ``client.get(...)``."""
+    captured: dict[str, httpx.Request] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["request"] = request
+        return mock_httpx_response(200, json={"mocked": True})
+
+    mock_transport = httpx.MockTransport(handler)
+    client = OPNsenseClient(
+        base_url="https://opnsense.local",
+        api_key="key",
+        api_secret="secret",
+        auto_detect_version=False,
+        transport=mock_transport,
+    )
+    result = client.get("core", "firmware", "info")
+    assert result == {"mocked": True}
+    # The request was routed through the injected transport to the built URL.
+    assert str(captured["request"].url) == "https://opnsense.local/api/core/firmware/info"

--- a/uv.lock
+++ b/uv.lock
@@ -209,19 +209,27 @@ sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
     { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
     { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
     { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
     { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
     { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
     { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
     { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
     { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
     { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
     { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
     { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
     { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
     { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
     { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
     { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
     { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
     { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
@@ -467,27 +475,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
     { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
     { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
     { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
     { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
     { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
     { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
     { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
     { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
     { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
     { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
     { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
     { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
     { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
     { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
     { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
     { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
     { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
     { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
     { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
     { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
     { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
     { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
     { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
     { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
     { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
     { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
@@ -701,6 +715,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -1583,6 +1602,9 @@ security = [
     { name = "pip-audit" },
     { name = "pip-licenses" },
 ]
+socks = [
+    { name = "httpx", extra = ["socks"] },
+]
 ui = [
     { name = "flask" },
     { name = "flask-swagger-ui" },
@@ -1598,7 +1620,8 @@ requires-dist = [
     { name = "doit", marker = "extra == 'dev'", specifier = ">=0.36.0" },
     { name = "flask", marker = "extra == 'ui'", specifier = ">=3.1.0" },
     { name = "flask-swagger-ui", marker = "extra == 'ui'", specifier = ">=5.21.0" },
-    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "httpx", extras = ["socks"], marker = "extra == 'socks'", specifier = ">=0.28.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.152.11" },
     { name = "jsonschema", specifier = ">=4.21.0" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5" },
@@ -1626,7 +1649,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20260518" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.11" },
 ]
-provides-extras = ["dev", "security", "ui"]
+provides-extras = ["dev", "security", "socks", "ui"]
 
 [[package]]
 name = "packageurl-python"
@@ -2411,6 +2434,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Exposes proxy/transport configuration on `OPNsenseClient`, threaded directly into the
underlying `httpx.Client`. The primary use case is reaching an OPNsense appliance that
is only accessible through an SSH tunnel — either a SOCKS proxy (`ssh -D`) or a local
port-forward (`ssh -L`) — without mutating process-global environment variables.

All five new parameters default to the existing behaviour, so this is a fully
backward-compatible, additive change.

## Related Issue

Addresses #63

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- **`src/opnsense_openapi/client/base.py`** — Five new `__init__` parameters:
  - `proxy` (`str | httpx.Proxy | None`, default `None`) — proxy URL for all requests; accepts plain HTTP or SOCKS URLs (`socks5h://`, `socks5://`, etc.)
  - `trust_env` (`bool`, default `True`) — whether to honour proxy env vars (`HTTP_PROXY`, `HTTPS_PROXY`, etc.); set to `False` to disable
  - `transport` (`httpx.BaseTransport | None`, default `None`) — custom transport, overrides `proxy`/`mounts`/`verify`
  - `mounts` (`dict[str, httpx.BaseTransport | None] | None`, default `None`) — per-URL-pattern transport map
  - `session` (`httpx.Client | None`, default `None`) — pre-built `httpx.Client`; caller retains ownership (`close()` is a no-op for injected sessions)
  - Session-ownership flag `_owns_client` guards `close()` so an injected session is never closed by the wrapper
  - Full Google-style docstring with httpx precedence rules documented
- **`pyproject.toml`** — httpx floor bumped from `>=0.27.0` to `>=0.28.0`; new `socks` optional extra (`httpx[socks]>=0.28.0`) for SOCKS proxy support
- **`uv.lock`** — re-locked for the httpx floor bump
- **`tests/test_client_base.py`** — 14 new tests covering:
  - `proxy`, `trust_env`, `transport`, `mounts` passthrough to `httpx.Client`
  - Default values (`proxy=None`, `transport=None`, `mounts=None`, `trust_env=True`)
  - Session injection: no `httpx.Client()` call, auth applied, headers merged, untouched without credentials
  - `close()` and context-manager exit do NOT close an injected session
  - `close()` DOES close an internally-built client
  - Functional `httpx.MockTransport` round-trip verifying transport wires through to `client.get()`
- **`README.md`** — "Accessing OPNsense Through an SSH Tunnel" section with both Option A (SOCKS proxy + `socks5h://`) and Option B (local port-forward)
- **`docs/usage/generated-client.md`** — "Proxy / Transport Configuration" subsection with parameter table, httpx precedence rules, SOCKS and port-forward examples, custom transport (testing), and injected session examples

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

14 new tests added in `tests/test_client_base.py` covering all new parameters and
session-ownership semantics. `doit check` passes (format, lint, type check, security
audit, spell check, full test suite).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

**No ADR required.** This is a small additive feature (5 new optional constructor
parameters, all defaulting to the current behaviour). The issue carries no `needs-adr`
label. The only client-related ADR in `docs/decisions/` is ADR-0001, which covers
spec-matching and resolved-version module paths — unrelated to transport configuration.

**httpx `>=0.28.0` floor:** httpx 0.28 introduced the unified `proxy=` parameter
(replacing the deprecated `proxies=` dict). The bump ensures all supported install
paths have the correct API. SOCKS support requires installing the `socks` extra
(`pip install "opnsense-openapi[socks]"`), which pulls in `socksio` via `httpx[socks]`.
httpx raises a clear `ImportError` if `socksio` is absent.
